### PR TITLE
Feature/add none wallet type 178099866

### DIFF
--- a/src/components/Login.tsx
+++ b/src/components/Login.tsx
@@ -38,7 +38,8 @@ const Login = (): JSX.Element => {
 
   const logout = () => {
     session.clearSession();
-    if (walletType) wallet.wallet(walletType).logout();
+    if (walletType !== wallet.WalletType.NONE)
+      wallet.wallet(walletType).logout();
     dispatch(userLogout());
   };
 

--- a/src/components/Login.tsx
+++ b/src/components/Login.tsx
@@ -1,5 +1,6 @@
 import React from "react";
-import { Alert, Button, Popover, Spin } from "antd";
+import { Alert, Badge, Button, Popover, Spin } from "antd";
+import { WalletOutlined } from "@ant-design/icons";
 import { useAppDispatch, useAppSelector } from "../redux/hooks";
 import { userLogin, userLogout } from "../redux/slices/userSlice";
 import * as sdk from "../services/sdk";
@@ -89,13 +90,17 @@ const Login = (): JSX.Element => {
         </Popover>
       ) : (
         <>
-          {walletType && (
+          <Badge
+            count={<WalletOutlined style={{ color: "#52C41A" }} />}
+            offset={[-48, 8]}
+          >
             <img
               className="Login__walletIcon"
               src={wallet.wallet(walletType).icon}
               alt="Wallet Symbol"
             ></img>
-          )}
+          </Badge>
+
           <Button
             className="Login__logOutButton"
             aria-label="Logout"

--- a/src/redux/slices/userSlice.ts
+++ b/src/redux/slices/userSlice.ts
@@ -5,14 +5,12 @@ import { Profile } from "../../utilities/types";
 
 interface UserState {
   profile?: Profile;
-  walletType?: wallet.WalletType;
+  walletType: wallet.WalletType;
 }
 
 const initialState: UserState = {
   profile: session.hasSession() ? session.loadSession()?.profile : undefined,
-  walletType: session.hasSession()
-    ? session.loadSession()?.walletType
-    : undefined,
+  walletType: session.loadSession()?.walletType ?? wallet.WalletType.NONE,
 };
 
 export const userSlice = createSlice({
@@ -25,12 +23,8 @@ export const userSlice = createSlice({
       return state;
     },
     userLogout: (state) => {
-      state.profile = session.hasSession()
-        ? session.loadSession()?.profile
-        : undefined;
-      state.walletType = session.hasSession()
-        ? session.loadSession()?.walletType
-        : undefined;
+      state.profile = undefined;
+      state.walletType = wallet.WalletType.NONE;
       return state;
     },
     userUpdateProfile: (state, action: PayloadAction<Profile>) => {

--- a/src/services/wallets/wallet.ts
+++ b/src/services/wallets/wallet.ts
@@ -12,6 +12,7 @@ import Web3 from "web3";
 // an example.
 
 export enum WalletType {
+  NONE = "NONE",
   TORUS = "TORUS",
   METAMASK = "METAMASK",
   // Add new WalletTypes Here
@@ -19,6 +20,8 @@ export enum WalletType {
 
 export const wallet = (walletType: WalletType): Wallet => {
   switch (walletType) {
+    case WalletType.NONE:
+      return noWallet;
     case WalletType.TORUS:
       return torusWallet;
     case WalletType.METAMASK:
@@ -35,3 +38,17 @@ export interface Wallet {
   getAddress: () => Promise<HexString>;
   getWeb3: () => Web3;
 }
+
+const noWallet: Wallet = {
+  icon:
+    "https://icons.veryicon.com/png/o/business/business-style-icon/wallet-62.png",
+  login: async () => await "",
+  logout: () => {
+    return;
+  },
+  reload: () => {
+    return;
+  },
+  getAddress: async () => await "",
+  getWeb3: () => new Web3(),
+};


### PR DESCRIPTION
Purpose
---------------
As a developer having a "none" `walletType` will allow us to deal with less nulls when checking for Wallets and their available data. Most wallet functions will not do anything and the "none" wallet type will effectively be the logged out state.


Solution
---------------
Added "none" wallet type that is the default state. No more dealing with union types for `walletType`. 


Change summary
---------------
* Changed redux slice state for walletType
* Changed walletType checks on login/logout


Steps to Verify
----------------
1) Start up example client, login button should appear
2) using login button works and it becomes logout
3) Logging out return button to login
4) You shouldn't be able to make posts or see followers and following while logged out. Should say "log in to see profile" or similar.

