### PR TITLE
allow for audio files, debug no-post error -> change error handling o…

### DIFF
--- a/src/components/NewPost.tsx
+++ b/src/components/NewPost.tsx
@@ -1,5 +1,5 @@
-import React, { useEffect } from "react";
-import { Alert, Button, Space, Spin, Modal, Input } from "antd";
+import React from "react";
+import { Button, Space, Spin, Modal, Input } from "antd";
 import { useAppSelector } from "../redux/hooks";
 import UserAvatar from "./UserAvatar";
 import NewPostImageUpload from "./NewPostImageUpload";

--- a/src/components/NewPost.tsx
+++ b/src/components/NewPost.tsx
@@ -14,7 +14,6 @@ interface NewPostProps {
 }
 
 const NewPost = ({ onSuccess, onCancel }: NewPostProps): JSX.Element => {
-  const [errorMsg, setErrorMsg] = React.useState<string | null>(null);
   const [saving, setSaving] = React.useState<boolean>(false);
   const [uriList, setUriList] = React.useState<string[]>([]);
   const [postMessage, setPostMessage] = React.useState<string>("");
@@ -22,15 +21,8 @@ const NewPost = ({ onSuccess, onCancel }: NewPostProps): JSX.Element => {
 
   const profile = useAppSelector((state) => state.user.profile);
 
-  useEffect(() => {
-    if (postMessage.length > 0 || uriList.length > 0) {
-      setIsValidPost(true);
-    } else setIsValidPost(false);
-  }, [postMessage, uriList]);
-
   const success = () => {
     setSaving(false);
-    setErrorMsg(null);
     onSuccess();
   };
 
@@ -43,6 +35,14 @@ const NewPost = ({ onSuccess, onCancel }: NewPostProps): JSX.Element => {
     );
     await sendPost(newPostFeedItem);
     success();
+  };
+
+  const handleMessageInputChange = (
+    e: React.ChangeEvent<HTMLTextAreaElement>
+  ) => {
+    if (saving) return;
+    e.target.value !== "" ? setIsValidPost(true) : setIsValidPost(false);
+    setPostMessage(e.target.value);
   };
 
   return (
@@ -82,16 +82,9 @@ const NewPost = ({ onSuccess, onCancel }: NewPostProps): JSX.Element => {
         className="NewPost__textArea"
         placeholder="Message"
         value={postMessage || ""}
-        onChange={(e) => {
-          if (saving) return;
-          setErrorMsg(null);
-          setPostMessage(e.target.value);
-        }}
+        onChange={(e) => handleMessageInputChange(e)}
         rows={6}
       />
-      {errorMsg && (
-        <Alert className="NewPost__alert" type="error" message={errorMsg} />
-      )}
       <NewPostImageUpload onNewPostImageUpload={setUriList} />
     </Modal>
   );

--- a/src/components/PostMedia.tsx
+++ b/src/components/PostMedia.tsx
@@ -11,40 +11,26 @@ interface PostMediaProps {
 const PostMedia = ({ attachment }: PostMediaProps): JSX.Element => {
   const getPostMediaItems = () => {
     return attachment?.map((item, index) => {
+      const type = item.type.toLowerCase();
       return (
         <div key={index} className="PostMedia__cover">
-          {item.type.toLowerCase() === "image" && (
+          {type === "image" && (
             <a
-              href={item.url[0].href as string}
+              href={item.url[0].href}
               target="_blank"
               rel="noopener noreferrer"
             >
-              <img
-                alt=""
-                className="PostMedia__img"
-                src={item.url[0].href as string}
-              />
+              <img alt="" className="PostMedia__img" src={item.url[0].href} />
             </a>
           )}
-          {item.type.toLowerCase() === "video" && (
+          {(type === "video" || type === "audio") && (
             <ReactPlayer
               controls
               playsinline
               className="PostMedia__img"
-              url={item.url[0].href as string}
+              url={item.url[0].href}
               width={670}
-              height={400}
-              muted
-            />
-          )}
-          {item.type.toLowerCase() === "audio" && (
-            <ReactPlayer
-              controls
-              playsinline
-              className="PostMedia__img"
-              url={item.url[0].href as string}
-              width={670}
-              height={55}
+              height={type === "video" ? 400 : 55}
               muted
             />
           )}

--- a/src/components/PostMedia.tsx
+++ b/src/components/PostMedia.tsx
@@ -15,11 +15,15 @@ const PostMedia = ({ attachment }: PostMediaProps): JSX.Element => {
         <div key={index} className="PostMedia__cover">
           {item.type.toLowerCase() === "image" && (
             <a
-              href={item.url[0].href}
+              href={item.url[0].href as string}
               target="_blank"
               rel="noopener noreferrer"
             >
-              <img alt="" className="PostMedia__img" src={item.url[0].href} />
+              <img
+                alt=""
+                className="PostMedia__img"
+                src={item.url[0].href as string}
+              />
             </a>
           )}
           {item.type.toLowerCase() === "video" && (
@@ -27,9 +31,20 @@ const PostMedia = ({ attachment }: PostMediaProps): JSX.Element => {
               controls
               playsinline
               className="PostMedia__img"
-              url={item.url[0].href}
-              width={535}
-              height={375}
+              url={item.url[0].href as string}
+              width={670}
+              height={400}
+              muted
+            />
+          )}
+          {item.type.toLowerCase() === "audio" && (
+            <ReactPlayer
+              controls
+              playsinline
+              className="PostMedia__img"
+              url={item.url[0].href as string}
+              width={670}
+              height={55}
               muted
             />
           )}

--- a/src/services/sdk.ts
+++ b/src/services/sdk.ts
@@ -195,7 +195,6 @@ const dispatchFeedItem = (
   if (!content.published) throw new Error("timestamp is required");
   // new Date(content.published).getTime()
   const timestamp = Date.parse(content.published);
-
   dispatch(
     addFeedItem({
       fromAddress: decoder.decode((message.fromId as any) as Uint8Array),
@@ -203,7 +202,7 @@ const dispatchFeedItem = (
       hash: decoder.decode((message.contentHash as any) as Uint8Array),
       timestamp: timestamp,
       uri: decoder.decode((message.url as any) as Uint8Array),
-      content: createNote(content.content),
+      content: content,
       inReplyTo:
         message.announcementType === core.announcements.AnnouncementType.Reply
           ? decoder.decode((message.inReplyTo as any) as Uint8Array)

--- a/src/services/sdk.ts
+++ b/src/services/sdk.ts
@@ -11,7 +11,6 @@ import { Store } from "./Storage";
 import {
   ActivityContentNote,
   ActivityContentProfile,
-  createNote,
   isActivityContentNote,
   isActivityContentProfile,
 } from "@dsnp/sdk/core/activityContent";

--- a/src/theme/antd-overrides.scss
+++ b/src/theme/antd-overrides.scss
@@ -147,14 +147,15 @@ a {
 }
 
 .slick-dots {
-  padding-bottom: 10px;
+  bottom: -6px !important;
+
   &>* {
     height: 15px !important;
 
     button {
       height: 15px !important;
       border-radius: 8px !important;
-      border: 1px solid $black !important;
+      background: $shadow-green !important;
     }
   }
 }

--- a/src/utilities/activityContent.ts
+++ b/src/utilities/activityContent.ts
@@ -8,6 +8,8 @@ import {
   createImageAttachment,
   createImageLink,
   createHash,
+  createAudioLink,
+  createAudioAttachment,
 } from "@dsnp/sdk/core/activityContent";
 
 const createMediaAttachment = (item: string): ActivityContentAttachment => {
@@ -33,6 +35,18 @@ const createMediaAttachment = (item: string): ActivityContentAttachment => {
       case "mov":
         return createVideoAttachment([
           createVideoLink(item, "video/quicktime", activityContentHashes),
+        ]);
+      case "webm":
+        return createVideoAttachment([
+          createVideoLink(item, "video/webm", activityContentHashes),
+        ]);
+      case "mp3":
+        return createAudioAttachment([
+          createAudioLink(item, "audio/mpeg", activityContentHashes),
+        ]);
+      case "ogg":
+        return createAudioAttachment([
+          createAudioLink(item, "audio/ogg", activityContentHashes),
         ]);
       default:
         return createImageAttachment([

--- a/src/utilities/activityContent.ts
+++ b/src/utilities/activityContent.ts
@@ -18,7 +18,6 @@ const createMediaAttachment = (item: string): ActivityContentAttachment => {
 
   const contentHash = createHash(item);
   const activityContentHashes: Array<ActivityContentHash> = [contentHash];
-
   if (supportedVideoDomains.test(item)) {
     const link = createVideoLink(item, "text/html", activityContentHashes);
     return createVideoAttachment([link]);
@@ -49,9 +48,15 @@ const createMediaAttachment = (item: string): ActivityContentAttachment => {
           createAudioLink(item, "audio/ogg", activityContentHashes),
         ]);
       default:
-        return createImageAttachment([
-          createImageLink(item, `image/${extension}`, activityContentHashes),
-        ]);
+        if (item.includes("soundcloud")) {
+          return createVideoAttachment([
+            createVideoLink(item, `video/${extension}`, activityContentHashes),
+          ]);
+        } else {
+          return createImageAttachment([
+            createImageLink(item, `image/${extension}`, activityContentHashes),
+          ]);
+        }
     }
   }
 };


### PR DESCRIPTION
Purpose
---------------
[https://www.pivotaltracker.com/story/show/179073517](url)
feature


Solution
---------------
currently, attachments are not saving or being displayed when you post a note.  the solution is to display attachments of all desired types.


Change summary
---------------
* allow for audio files to be played
* pass all content, including attachments to the redux stote instead of just content.content
* a little bit of styling
* found bug that did not display post when there was no message
 -> fix error handling to enforce entering a message 


Steps to Verify
----------------
- save images
- save videos
- save audio
- save different types of media on the same carousel


Additional details / screenshot
----------------
![Screen Shot 2021-08-03 at 2 18 24 PM](https://user-images.githubusercontent.com/43625033/128087612-8eb2d3c2-c48f-4623-a96c-9f6acb047cdd.png)
