### PR TITLE
Retrieve DSNP Id

### DIFF
--- a/src/components/Login.tsx
+++ b/src/components/Login.tsx
@@ -27,16 +27,19 @@ const Login = ({ loginWalletOptions }: LoginProps): JSX.Element => {
     startLoading(true);
     try {
       const walletAddress = await wallet.wallet(walletType).login();
-      const socialAddress = await sdk.getSocialIdentity(walletAddress);
-      const graph = await sdk.getGraph(socialAddress);
-      dispatch(userLogin({ id: "0x03ee", walletType }));
-      dispatch(upsertGraph(graph));
-      session.saveSession({ id: "0x03ee", walletType });
       sdk.setupProvider(walletType);
+      const socialAddress = await sdk.getSocialIdentity(walletAddress);
+      if (socialAddress) {
+        const graph = await sdk.getGraph(socialAddress);
+        dispatch(userLogin({ id: socialAddress, walletType }));
+        dispatch(upsertGraph(graph));
+        session.saveSession({ id: socialAddress, walletType });
+      }
     } catch (error) {
       console.log("Error in login:", error);
-      startLoading(false);
+    } finally {
       setPopoverVisible(false);
+      startLoading(false);
     }
   };
 

--- a/src/components/test/Login.test.tsx
+++ b/src/components/test/Login.test.tsx
@@ -23,6 +23,9 @@ beforeAll(async () => {
     .spyOn(metamask, "getWalletAddress")
     .mockImplementation(() => Promise.resolve("0x123"));
   jest.spyOn(sdk, "setupProvider").mockImplementation(jest.fn);
+  jest
+    .spyOn(sdk, "getSocialIdentity")
+    .mockImplementation(() => Promise.resolve("0x034b"));
 });
 
 describe("Login Component", () => {

--- a/src/components/test/LoginSetupInstructions.test.tsx
+++ b/src/components/test/LoginSetupInstructions.test.tsx
@@ -23,6 +23,9 @@ beforeAll(async () => {
     .spyOn(metamaskWallet, "login")
     .mockImplementation(() => Promise.resolve("0x123"));
   jest.spyOn(sdk, "setupProvider").mockImplementation(jest.fn);
+  jest
+    .spyOn(sdk, "getSocialIdentity")
+    .mockImplementation(() => Promise.resolve("0x034b"));
 });
 
 describe("LoginSetupInstructions Component", () => {

--- a/src/redux/slices/userSlice.ts
+++ b/src/redux/slices/userSlice.ts
@@ -21,7 +21,7 @@ export const userSlice = createSlice({
       ...state,
       ...action.payload,
     }),
-    userLogout: (state) => ({ ...state, walletType: wallet.WalletType.NONE }),
+    userLogout: (_state) => ({ walletType: wallet.WalletType.NONE }),
     userUpdateId: (state, action: PayloadAction<DSNPUserId>) => ({
       ...state,
       id: action.payload,

--- a/src/services/sdk.ts
+++ b/src/services/sdk.ts
@@ -3,7 +3,7 @@ import * as fakesdk from "./fakesdk";
 import { setConfig, core } from "@dsnp/sdk";
 import { Publication } from "@dsnp/sdk/core/contracts/publisher";
 import { RegistryUpdateLogData } from "@dsnp/sdk/core/contracts/registry";
-import { providers } from "ethers";
+import { providers, utils as ethUtils } from "ethers";
 import { keccak256 } from "web3-utils";
 import { addFeedItem, clearFeedItems } from "../redux/slices/feedSlice";
 import { upsertProfile } from "../redux/slices/profileSlice";
@@ -36,16 +36,17 @@ type Dispatch = ThunkDispatch<any, Record<string, any>, AnyAction>;
 
 export const getSocialIdentity = async (
   walletAddress: HexString
-): Promise<HexString> => {
-  let socialAddress: HexString = await fakesdk.getSocialIdentityfromWalletAddress(
-    walletAddress
+): Promise<HexString | undefined> => {
+  const registrations = await core.contracts.registry.getRegistrationsByWalletAddress(
+    ethUtils.getAddress(walletAddress)
   );
-  if (!socialAddress) {
-    socialAddress = await fakesdk.createSocialIdentityfromWalletAddress(
-      walletAddress
-    );
-  }
-  return socialAddress;
+
+  const userId = registrations.length
+    ? core.identifiers.convertDSNPUserURIToDSNPUserId(
+        registrations[0].dsnpUserURI
+      )
+    : undefined;
+  return userId;
 };
 
 export const getGraph = async (socialAddress: HexString): Promise<Graph> => {


### PR DESCRIPTION
Purpose
---------------
Once the user has logged in with Metamask or Torus, we only have a wallet address. We need to have a DSNP id to interact with any of the content.

Solution
---------------
This PR adds the SDK call to retrieve DSNP registrations by wallet address. It then simply picks the first one available. It uses it then gets the user's id from its dsnpURI.

Change summary
---------------
* Replace fake `sdk.getSocialIdentity` method with one that calls `getRegistrationsByWalletAddress`
* Rearrange login code so provider is set before `getSocialIdentity` is called.
* Mock the getSocialIdentity call in tests.


Steps to Verify
----------------
1. Ensure you metamask account address is one of the ones in the generator script (this is necessary to have a balance anyway).
2. Sst up the app (start chain, deploy, generate, run).
3. Log in using metamask. You should see a valid profile to the right and a matching post on the left.
4. Create a new metamask account using a different address from the generator script.
5. Log in with new address. The profile and "You" feed should have changed.

Draft pending #51
