### PR TITLE
add spinner to posts and replies while loading

### DIFF
--- a/src/App.scss
+++ b/src/App.scss
@@ -1,5 +1,6 @@
 @import "theme/colors";
 @import "theme/typography";
+@import "theme/mixins";
 @import "theme/buttons";
 @import "theme/antd-overrides";
 @import "theme/kss-styleguide-classes";
@@ -12,6 +13,7 @@
 @import "./components/scss/NewPost";
 @import "./components/scss/NewPostImageUpload";
 @import "./components/scss/Post";
+@import "./components/scss/BlankPost";
 @import "./components/scss/PostMedia";
 @import "./components/scss/ConnectionsList";
 @import "./components/scss/ConnectionsListProfiles";
@@ -19,6 +21,7 @@
 @import "components/scss/ReplyBlock";
 @import "components/scss/ReplyInput";
 @import "components/scss/Reply";
+@import "components/scss/BlankReply";
 
 .App__content {
   display: flex;

--- a/src/components/BlankPost.tsx
+++ b/src/components/BlankPost.tsx
@@ -1,0 +1,26 @@
+import React from "react";
+import { Card } from "antd";
+import UserAvatar from "./UserAvatar";
+
+const BlankPost = (): JSX.Element => {
+  return (
+    <Card className="BlankPost__block" bordered={false}>
+      <Card.Meta
+        avatar={
+          <UserAvatar
+            icon={undefined}
+            profileAddress={undefined}
+            avatarSize={"medium"}
+          />
+        }
+        title={<div className="BlankPost__title"> </div>}
+        description={<div className="BlankPost__description"> </div>}
+      />
+      <div className="BlankPost__contentLine1"> </div>
+      <div className="BlankPost__contentLine2"> </div>
+      <div className="BlankPost__contentLine3"> </div>
+    </Card>
+  );
+};
+
+export default BlankPost;

--- a/src/components/BlankReply.tsx
+++ b/src/components/BlankReply.tsx
@@ -1,0 +1,20 @@
+import React from "react";
+import UserAvatar from "./UserAvatar";
+
+const BlankReply = (): JSX.Element => {
+  return (
+    <div className="BlankReply__block">
+      <UserAvatar
+        icon={undefined}
+        profileAddress={undefined}
+        avatarSize="small"
+      />
+      <div className="BlankReply__messageBlock">
+        <div className="BlankReply__name"> </div>
+        <div className="BlankReply__message"> </div>
+      </div>
+    </div>
+  );
+};
+
+export default BlankReply;

--- a/src/components/Feed.tsx
+++ b/src/components/Feed.tsx
@@ -55,9 +55,7 @@ const Feed = (): JSX.Element => {
         )}
         {isModalOpen && (
           <NewPost
-            onSuccess={() => {
-              setIsModalOpen(false);
-            }}
+            onSuccess={() => setIsModalOpen(false)}
             onCancel={() => setIsModalOpen(false)}
           />
         )}

--- a/src/components/Feed.tsx
+++ b/src/components/Feed.tsx
@@ -14,7 +14,6 @@ const Feed = (): JSX.Element => {
   const userId = useAppSelector((state) => state.user.id);
   const [isModalOpen, setIsModalOpen] = useState<boolean>(false);
   const [feedType, setFeedType] = useState<FeedTypes>(FeedTypes.FEED);
-  const [showPostSpinner, setShowPostSpinner] = React.useState<boolean>(false);
 
   const feedNavClassName = (navItemType: number) =>
     feedType === navItemType
@@ -58,17 +57,12 @@ const Feed = (): JSX.Element => {
           <NewPost
             onSuccess={() => {
               setIsModalOpen(false);
-              setShowPostSpinner(true);
             }}
             onCancel={() => setIsModalOpen(false)}
           />
         )}
       </div>
-      <PostList
-        feedType={feedType}
-        showPostSpinner={showPostSpinner}
-        setShowPostSpinner={setShowPostSpinner}
-      />
+      <PostList feedType={feedType} />
     </div>
   );
 };

--- a/src/components/Feed.tsx
+++ b/src/components/Feed.tsx
@@ -14,6 +14,7 @@ const Feed = (): JSX.Element => {
   const userId = useAppSelector((state) => state.user.id);
   const [isModalOpen, setIsModalOpen] = useState<boolean>(false);
   const [feedType, setFeedType] = useState<FeedTypes>(FeedTypes.FEED);
+  const [showPostSpinner, setShowPostSpinner] = React.useState<boolean>(false);
 
   const feedNavClassName = (navItemType: number) =>
     feedType === navItemType
@@ -55,12 +56,19 @@ const Feed = (): JSX.Element => {
         )}
         {isModalOpen && (
           <NewPost
-            onSuccess={() => setIsModalOpen(false)}
+            onSuccess={() => {
+              setIsModalOpen(false);
+              setShowPostSpinner(true);
+            }}
             onCancel={() => setIsModalOpen(false)}
           />
         )}
       </div>
-      <PostList feedType={feedType} />
+      <PostList
+        feedType={feedType}
+        showPostSpinner={showPostSpinner}
+        setShowPostSpinner={setShowPostSpinner}
+      />
     </div>
   );
 };

--- a/src/components/NewPost.tsx
+++ b/src/components/NewPost.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { Button, Space, Spin, Modal, Input } from "antd";
-import { useAppSelector } from "../redux/hooks";
+import { useAppDispatch, useAppSelector } from "../redux/hooks";
 import UserAvatar from "./UserAvatar";
 import NewPostImageUpload from "./NewPostImageUpload";
 import { FeedItem, HexString, Profile } from "../utilities/types";
@@ -9,6 +9,7 @@ import { sendPost } from "../services/sdk";
 import { createProfile } from "@dsnp/sdk/core/activityContent";
 import { FromTitle } from "./FromTitle";
 import { DSNPUserId } from "@dsnp/sdk/dist/types/core/identifiers";
+import { postLoading } from "../redux/slices/feedSlice";
 
 interface NewPostProps {
   onSuccess: () => void;
@@ -16,6 +17,7 @@ interface NewPostProps {
 }
 
 const NewPost = ({ onSuccess, onCancel }: NewPostProps): JSX.Element => {
+  const dispatch = useAppDispatch();
   const [saving, setSaving] = React.useState<boolean>(false);
   const [uriList, setUriList] = React.useState<string[]>([]);
   const [postMessage, setPostMessage] = React.useState<string>("");
@@ -47,6 +49,7 @@ const NewPost = ({ onSuccess, onCancel }: NewPostProps): JSX.Element => {
       userId
     );
     await sendPost(newPostFeedItem);
+    dispatch(postLoading(true));
     success();
   };
 

--- a/src/components/NewPost.tsx
+++ b/src/components/NewPost.tsx
@@ -49,8 +49,7 @@ const NewPost = ({ onSuccess, onCancel }: NewPostProps): JSX.Element => {
       userId
     );
     await sendPost(newPostFeedItem);
-    console.log(newPostFeedItem);
-    dispatch(postLoading({ loading: true, myIdentifier: userId }));
+    dispatch(postLoading({ loading: true, currentUserId: userId }));
     success();
   };
 

--- a/src/components/NewPost.tsx
+++ b/src/components/NewPost.tsx
@@ -49,7 +49,8 @@ const NewPost = ({ onSuccess, onCancel }: NewPostProps): JSX.Element => {
       userId
     );
     await sendPost(newPostFeedItem);
-    dispatch(postLoading(true));
+    console.log(newPostFeedItem);
+    dispatch(postLoading({ loading: true, myIdentifier: userId }));
     success();
   };
 

--- a/src/components/Post.tsx
+++ b/src/components/Post.tsx
@@ -31,7 +31,7 @@ const Post = ({ feedItem }: PostProps): JSX.Element => {
         avatar={
           <UserAvatar
             icon={profile.icon?.[0]?.href}
-            profileAddress={feedItem.fromAddress}
+            profileAddress={feedItem.fromId}
             avatarSize={"medium"}
           />
         }

--- a/src/components/PostList.tsx
+++ b/src/components/PostList.tsx
@@ -25,8 +25,9 @@ const PostList = ({ feedType }: PostListProps): JSX.Element => {
   const feed: FeedItem[] = useAppSelector((state) => state.feed.feed).filter(
     (post) => post?.content?.type === "Note" && post?.inReplyTo === undefined
   );
-
-  const loading: boolean = useAppSelector((state) => state.feed.isPostLoading);
+  const loading: boolean = useAppSelector(
+    (state) => state.feed.isPostLoading.loading
+  );
 
   let currentFeed: FeedItem[] = [];
 

--- a/src/components/PostList.tsx
+++ b/src/components/PostList.tsx
@@ -1,8 +1,9 @@
-import React, { useEffect } from "react";
+import React from "react";
 import Post from "./Post";
 import { FeedItem } from "../utilities/types";
 import { useAppSelector } from "../redux/hooks";
 import { DSNPUserId } from "@dsnp/sdk/dist/types/core/identifiers";
+import BlankPost from "./BlankPost";
 
 enum FeedTypes {
   FEED,
@@ -25,6 +26,8 @@ const PostList = ({ feedType }: PostListProps): JSX.Element => {
     (post) => post?.content?.type === "Note" && post?.inReplyTo === undefined
   );
 
+  const loading: boolean = useAppSelector((state) => state.feed.isPostLoading);
+
   let currentFeed: FeedItem[] = [];
 
   if (feedType === FeedTypes.FEED) {
@@ -39,30 +42,15 @@ const PostList = ({ feedType }: PostListProps): JSX.Element => {
 
   return (
     <div className="PostList__block">
+      {loading && <BlankPost />}
       {currentFeed.length > 0 ? (
         <>
           {currentFeed
             .slice(0)
             .reverse()
-<<<<<<< HEAD
             .map((post, index) => (
               <Post key={index} feedItem={post} />
             ))}
-=======
-            .map((post, index) => {
-              if (!post.fromAddress)
-                throw new Error(`no fromAddress in post: ${post}`);
-              const fromAddress: string = profiles[post.fromAddress]
-                ? (profiles[post.fromAddress].name as string)
-                : post.fromAddress;
-
-              const namedPost: FeedItem<ActivityContentNote> = {
-                ...post,
-                fromAddress,
-              };
-              return <Post key={index} feedItem={namedPost} />;
-            })}
->>>>>>> ba8b109 (wip)
         </>
       ) : (
         "Empty Feed!"

--- a/src/components/PostList.tsx
+++ b/src/components/PostList.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useEffect } from "react";
 import Post from "./Post";
 import { FeedItem } from "../utilities/types";
 import { useAppSelector } from "../redux/hooks";
@@ -24,6 +24,7 @@ const PostList = ({ feedType }: PostListProps): JSX.Element => {
   const feed: FeedItem[] = useAppSelector((state) => state.feed.feed).filter(
     (post) => post?.content?.type === "Note" && post?.inReplyTo === undefined
   );
+
   let currentFeed: FeedItem[] = [];
 
   if (feedType === FeedTypes.FEED) {

--- a/src/components/PostList.tsx
+++ b/src/components/PostList.tsx
@@ -44,9 +44,25 @@ const PostList = ({ feedType }: PostListProps): JSX.Element => {
           {currentFeed
             .slice(0)
             .reverse()
+<<<<<<< HEAD
             .map((post, index) => (
               <Post key={index} feedItem={post} />
             ))}
+=======
+            .map((post, index) => {
+              if (!post.fromAddress)
+                throw new Error(`no fromAddress in post: ${post}`);
+              const fromAddress: string = profiles[post.fromAddress]
+                ? (profiles[post.fromAddress].name as string)
+                : post.fromAddress;
+
+              const namedPost: FeedItem<ActivityContentNote> = {
+                ...post,
+                fromAddress,
+              };
+              return <Post key={index} feedItem={namedPost} />;
+            })}
+>>>>>>> ba8b109 (wip)
         </>
       ) : (
         "Empty Feed!"
@@ -54,4 +70,5 @@ const PostList = ({ feedType }: PostListProps): JSX.Element => {
     </div>
   );
 };
+
 export default PostList;

--- a/src/components/Profile.tsx
+++ b/src/components/Profile.tsx
@@ -47,6 +47,12 @@ const Profile = (): JSX.Element => {
 
   const saveEditProfile = async () => {
     setIsEditing(!isEditing);
+    if (userId === undefined || newName === undefined) return;
+    const newProfile = core.activityContent.createProfile({
+      name: newName,
+      icon: profile?.icon,
+    });
+    await saveProfile(userId, newProfile);
   };
 
   const cancelEditProfile = () => {

--- a/src/components/Profile.tsx
+++ b/src/components/Profile.tsx
@@ -26,6 +26,7 @@ const Profile = (): JSX.Element => {
   const [didEditProfile, setDidEditProfile] = useState<boolean>(false);
 
   const profileName = profile?.name || "Anonymous";
+
   useEffect(() => {
     if (
       (newName && newName !== profileName) ||
@@ -46,12 +47,6 @@ const Profile = (): JSX.Element => {
 
   const saveEditProfile = async () => {
     setIsEditing(!isEditing);
-    if (userId === undefined || newName === undefined) return;
-    const newProfile = core.activityContent.createProfile({
-      name: newName,
-      icon: profile?.icon,
-    });
-    await saveProfile(userId, newProfile);
   };
 
   const cancelEditProfile = () => {

--- a/src/components/Reply.tsx
+++ b/src/components/Reply.tsx
@@ -23,7 +23,7 @@ const Reply = ({ reply }: ReplyProps): JSX.Element => {
     <div className="Reply__block">
       <UserAvatar
         icon={fromProfile?.icon?.[0]?.href}
-        profileAddress={reply.fromAddress}
+        profileAddress={reply.fromId}
         avatarSize="small"
       />
       <div className="Reply__message">

--- a/src/components/ReplyBlock.tsx
+++ b/src/components/ReplyBlock.tsx
@@ -3,6 +3,7 @@ import { useAppSelector } from "../redux/hooks";
 import { FeedItem, HexString } from "../utilities/types";
 import Reply from "./Reply";
 import ReplyInput from "./ReplyInput";
+import BlankReply from "./BlankReply";
 
 interface ReplyBlockProps {
   parent: HexString;
@@ -15,13 +16,20 @@ const ReplyBlock = ({ parent }: ReplyBlockProps): JSX.Element => {
     return reply?.content?.type === "Note" && reply?.inReplyTo === parent;
   }) as FeedItem[];
 
+  const loading: any = useAppSelector((state) => state.feed.isReplyLoading);
+
   return (
     <>
-      {replyFeed.length > 0 && (
+      {(parent === loading?.parent || replyFeed.length > 0) && (
         <div className="ReplyBlock__repliesList">
-          {replyFeed.map((reply, index) => (
-            <Reply reply={reply} key={index} />
-          ))}
+          {replyFeed.length > 0 && (
+            <>
+              {replyFeed.map((reply, index) => (
+                <Reply reply={reply} key={index} />
+              ))}
+              {parent === loading?.parent && <BlankReply />}
+            </>
+          )}
         </div>
       )}
       <ReplyInput parent={parent} />

--- a/src/components/ReplyBlock.tsx
+++ b/src/components/ReplyBlock.tsx
@@ -5,6 +5,11 @@ import Reply from "./Reply";
 import ReplyInput from "./ReplyInput";
 import BlankReply from "./BlankReply";
 
+interface isReplyLoadingType {
+  loading: boolean;
+  parent: HexString | undefined;
+}
+
 interface ReplyBlockProps {
   parent: HexString;
 }
@@ -16,7 +21,9 @@ const ReplyBlock = ({ parent }: ReplyBlockProps): JSX.Element => {
     return reply?.content?.type === "Note" && reply?.inReplyTo === parent;
   }) as FeedItem[];
 
-  const loading: any = useAppSelector((state) => state.feed.isReplyLoading);
+  const loading: isReplyLoadingType = useAppSelector(
+    (state) => state.feed.isReplyLoading
+  );
 
   return (
     <>
@@ -27,9 +34,9 @@ const ReplyBlock = ({ parent }: ReplyBlockProps): JSX.Element => {
               {replyFeed.map((reply, index) => (
                 <Reply reply={reply} key={index} />
               ))}
-              {parent === loading?.parent && <BlankReply />}
             </>
           )}
+          {parent === loading?.parent && <BlankReply />}
         </div>
       )}
       <ReplyInput parent={parent} />

--- a/src/components/ReplyInput.tsx
+++ b/src/components/ReplyInput.tsx
@@ -3,13 +3,15 @@ import React, { useState } from "react";
 import { createNote } from "../services/Storage";
 import { sendReply } from "../services/sdk";
 import { HexString } from "../utilities/types";
-import { useAppSelector } from "../redux/hooks";
+import { useAppDispatch, useAppSelector } from "../redux/hooks";
+import { replyLoading } from "../redux/slices/feedSlice";
 
 interface ReplyInputProps {
   parent: HexString;
 }
 
 const ReplyInput = ({ parent }: ReplyInputProps): JSX.Element => {
+  const dispatch = useAppDispatch();
   const userId = useAppSelector((state) => state.user.id);
   const [saving, setSaving] = React.useState<boolean>(false);
   const [replyValue, setReplyValue] = useState<string>("");
@@ -22,6 +24,7 @@ const ReplyInput = ({ parent }: ReplyInputProps): JSX.Element => {
     setSaving(true);
     const newReplyFeedItem = await createNote(replyValue, [], userId);
     await sendReply(newReplyFeedItem, parent);
+    dispatch(replyLoading({ loading: true, parent: parent }));
     setReplyValue("");
     setSaving(false);
   };

--- a/src/components/scss/BlankPost.scss
+++ b/src/components/scss/BlankPost.scss
@@ -1,0 +1,27 @@
+.BlankPost__block {
+  background-color: $light-gray !important;
+  width: 100%;
+  margin-top: 16px !important;
+  border-radius: 10px !important;
+}
+
+.BlankPost__title {
+  @include mock-text(80px);
+}
+
+.BlankPost__description {
+  @include mock-text(40px);
+}
+
+.BlankPost__contentLine1 {
+  @include mock-text(240px);
+  margin-top: 16px;
+}
+
+.BlankPost__contentLine2 {
+  @include mock-text(280px);
+}
+
+.BlankPost__contentLine3 {
+  @include mock-text(200px);
+}

--- a/src/components/scss/BlankReply.scss
+++ b/src/components/scss/BlankReply.scss
@@ -1,0 +1,23 @@
+.BlankReply__block {
+  display: flex;
+  justify-content: center;
+  padding-bottom: 14px;
+  max-height: 400px;
+}
+
+.BlankReply__messageBlock {
+  align-self: center;
+  background-color: $light-gray;
+  padding: 4px;
+  border-radius: 8px;
+  margin-left: 8px;
+  width: 90%;
+}
+
+.BlankReply__name {
+  @include mock-text(60px);
+}
+
+.BlankReply__message {
+  @include mock-text(200px);
+}

--- a/src/components/test/Feed.test.tsx
+++ b/src/components/test/Feed.test.tsx
@@ -11,7 +11,11 @@ const feed = getPrefabFeed();
 const graphs = getPreFabSocialGraph();
 const initialState = {
   user: { id: userId },
-  feed: { feed },
+  feed: {
+    feed: feed,
+    isPostLoading: { loading: false, myIdentifier: undefined },
+    isReplyLoading: { loading: false, parent: undefined },
+  },
   graphs: graphs,
 };
 const store = createMockStore(initialState);
@@ -31,7 +35,11 @@ describe("Feed", () => {
   it("does not display new post button when not logged in", () => {
     const initialState = {
       user: {},
-      feed: { feed },
+      feed: {
+        feed: feed,
+        isPostLoading: { loading: false, myIdentifier: undefined },
+        isReplyLoading: { loading: false, parent: undefined },
+      },
       graphs: { graphs },
     };
     const store = createMockStore(initialState);

--- a/src/redux/slices/feedSlice.ts
+++ b/src/redux/slices/feedSlice.ts
@@ -1,6 +1,11 @@
 import { createSlice, PayloadAction } from "@reduxjs/toolkit";
 import { FeedItem, HexString } from "../../utilities/types";
 
+interface isPostLoadingType {
+  loading: boolean;
+  myIdentifier: HexString | undefined;
+}
+
 interface isReplyLoadingType {
   loading: boolean;
   parent: HexString | undefined;
@@ -8,13 +13,13 @@ interface isReplyLoadingType {
 
 interface feedState {
   feed: FeedItem[];
-  isPostLoading: boolean;
+  isPostLoading: isPostLoadingType;
   isReplyLoading: isReplyLoadingType;
 }
 
 const initialState: feedState = {
   feed: [],
-  isPostLoading: false,
+  isPostLoading: { loading: false, myIdentifier: undefined },
   isReplyLoading: { loading: false, parent: undefined },
 };
 
@@ -24,11 +29,17 @@ export const feedSlice = createSlice({
   reducers: {
     addFeedItem: (state, action: PayloadAction<FeedItem>) => {
       const newFeedItem = action.payload;
+      if (state.isPostLoading.myIdentifier === newFeedItem.fromId) {
+        return {
+          ...state,
+          feed: [...state.feed, newFeedItem],
+          isPostLoading: { loading: false, myIdentifier: undefined },
+          isReplyLoading: { loading: false, parent: undefined },
+        };
+      }
       return {
         ...state,
         feed: [...state.feed, newFeedItem],
-        isPostLoading: false,
-        isReplyLoading: { loading: false, parent: undefined },
       };
     },
     addFeedItems: (state, action: PayloadAction<FeedItem[]>) => {
@@ -44,17 +55,18 @@ export const feedSlice = createSlice({
         feed: [],
       };
     },
-    postLoading: (state, isLoading: PayloadAction<boolean>) => {
+    postLoading: (state, isLoading: PayloadAction<isPostLoadingType>) => {
       return {
         ...state,
-        feed: [...state.feed],
-        isPostLoading: isLoading.payload,
+        isPostLoading: {
+          loading: isLoading.payload.loading,
+          myIdentifier: isLoading.payload.myIdentifier,
+        },
       };
     },
     replyLoading: (state, isLoading: PayloadAction<isReplyLoadingType>) => {
       return {
         ...state,
-        feed: [...state.feed],
         isReplyLoading: {
           loading: isLoading.payload.loading,
           parent: isLoading.payload.parent,

--- a/src/redux/slices/feedSlice.ts
+++ b/src/redux/slices/feedSlice.ts
@@ -1,12 +1,16 @@
 import { createSlice, PayloadAction } from "@reduxjs/toolkit";
-import { FeedItem } from "../../utilities/types";
+import { FeedItem, HexString } from "../../utilities/types";
 
 interface feedState {
   feed: FeedItem[];
+  isPostLoading: boolean;
+  isReplyLoading: { loading: boolean; parent: HexString | undefined };
 }
 
 const initialState: feedState = {
   feed: [],
+  isPostLoading: false,
+  isReplyLoading: { loading: false, parent: undefined },
 };
 
 export const feedSlice = createSlice({
@@ -18,6 +22,8 @@ export const feedSlice = createSlice({
       return {
         ...state,
         feed: [...state.feed, newFeedItem],
+        isPostLoading: false,
+        isReplyLoading: { loading: false, parent: undefined },
       };
     },
     addFeedItems: (state, action: PayloadAction<FeedItem[]>) => {
@@ -33,7 +39,30 @@ export const feedSlice = createSlice({
         feed: [],
       };
     },
+    postLoading: (state, isLoading: PayloadAction<boolean>) => {
+      return {
+        ...state,
+        feed: [...state.feed],
+        isPostLoading: isLoading.payload,
+      };
+    },
+    replyLoading: (state, isLoading: PayloadAction<any>) => {
+      return {
+        ...state,
+        feed: [...state.feed],
+        isReplyLoading: {
+          loading: isLoading.payload.loading,
+          parent: isLoading.payload.parent,
+        },
+      };
+    },
   },
 });
-export const { addFeedItem, addFeedItems, clearFeedItems } = feedSlice.actions;
+export const {
+  addFeedItem,
+  addFeedItems,
+  clearFeedItems,
+  postLoading,
+  replyLoading,
+} = feedSlice.actions;
 export default feedSlice.reducer;

--- a/src/redux/slices/feedSlice.ts
+++ b/src/redux/slices/feedSlice.ts
@@ -1,10 +1,15 @@
 import { createSlice, PayloadAction } from "@reduxjs/toolkit";
 import { FeedItem, HexString } from "../../utilities/types";
 
+interface isReplyLoadingType {
+  loading: boolean;
+  parent: HexString | undefined;
+}
+
 interface feedState {
   feed: FeedItem[];
   isPostLoading: boolean;
-  isReplyLoading: { loading: boolean; parent: HexString | undefined };
+  isReplyLoading: isReplyLoadingType;
 }
 
 const initialState: feedState = {
@@ -46,7 +51,7 @@ export const feedSlice = createSlice({
         isPostLoading: isLoading.payload,
       };
     },
-    replyLoading: (state, isLoading: PayloadAction<any>) => {
+    replyLoading: (state, isLoading: PayloadAction<isReplyLoadingType>) => {
       return {
         ...state,
         feed: [...state.feed],

--- a/src/redux/slices/feedSlice.ts
+++ b/src/redux/slices/feedSlice.ts
@@ -3,7 +3,7 @@ import { FeedItem, HexString } from "../../utilities/types";
 
 interface isPostLoadingType {
   loading: boolean;
-  myIdentifier: HexString | undefined;
+  currentUserId: HexString | undefined;
 }
 
 interface isReplyLoadingType {
@@ -19,7 +19,7 @@ interface feedState {
 
 const initialState: feedState = {
   feed: [],
-  isPostLoading: { loading: false, myIdentifier: undefined },
+  isPostLoading: { loading: false, currentUserId: undefined },
   isReplyLoading: { loading: false, parent: undefined },
 };
 
@@ -29,11 +29,13 @@ export const feedSlice = createSlice({
   reducers: {
     addFeedItem: (state, action: PayloadAction<FeedItem>) => {
       const newFeedItem = action.payload;
-      if (state.isPostLoading.myIdentifier === newFeedItem.fromId) {
+      if (state.isPostLoading.currentUserId === newFeedItem.fromId) {
+        // to keep loading from being turned off when some else's post
+        // arrives while waiting for the current user's to appear.
         return {
           ...state,
           feed: [...state.feed, newFeedItem],
-          isPostLoading: { loading: false, myIdentifier: undefined },
+          isPostLoading: { loading: false, currentUserId: undefined },
           isReplyLoading: { loading: false, parent: undefined },
         };
       }
@@ -60,7 +62,7 @@ export const feedSlice = createSlice({
         ...state,
         isPostLoading: {
           loading: isLoading.payload.loading,
-          myIdentifier: isLoading.payload.myIdentifier,
+          currentUserId: isLoading.payload.currentUserId,
         },
       };
     },

--- a/src/services/Storage.ts
+++ b/src/services/Storage.ts
@@ -20,11 +20,9 @@ export const createNote = async (
     note,
     uriList
   );
-  const newPostFeedItem: FeedItem = {
+  const newPostFeedItem: Partial<FeedItem> = {
     fromId: fromId,
     content: activityPubNote,
-    blockNumber: 0x123,
-    hash: "0x89205A3A3b2A69De6Dbf7f01ED13B2108B2c43e7",
   };
   return newPostFeedItem;
 };

--- a/src/services/sdk.ts
+++ b/src/services/sdk.ts
@@ -222,7 +222,6 @@ const dispatchFeedItem = (
   blockNumber: number
 ) => {
   const decoder = new TextDecoder();
-
   dispatch(
     addFeedItem({
       fromId: decoder.decode((message.fromId as any) as Uint8Array),

--- a/src/services/sdk.ts
+++ b/src/services/sdk.ts
@@ -365,7 +365,6 @@ const storeActivityContent = async (
   content: ActivityContentNote | ActivityContentProfile
 ): Promise<string> => {
   const hash = keccak256(core.activityContent.serialize(content));
-
   await fetch(
     `${process.env.REACT_APP_UPLOAD_HOST}/upload?filename=${encodeURIComponent(
       hash + ".json"

--- a/src/theme/_mixins.scss
+++ b/src/theme/_mixins.scss
@@ -1,0 +1,40 @@
+@mixin mock-text($width) {
+  height: 8px;
+  width: $width;
+  margin-bottom: 10px;
+  -webkit-animation: background-color-change 3s infinite;
+  -moz-animation: background-color-change 3s infinite;
+  -o-animation: background-color-change 3s infinite;
+  -ms-animation: background-color-change 3s infinite;
+  animation: background-color-change 3s infinite;
+}
+
+@-webkit-keyframes background-color-change {
+  0% { background-color: $text-gray; }
+  50% { background-color: $gray; }
+  100% { background-color: $text-gray; }
+}
+
+@-moz-keyframes background-color-change {
+  0% { background-color: $text-gray; }
+  50% { background-color: $gray; }
+  100% { background-color: $text-gray; }
+}
+
+@-ms-keyframes background-color-change {
+  0% { background-color: $text-gray; }
+  50% { background-color: $gray; }
+  100% { background-color: $text-gray; }
+}
+
+@-o-keyframes background-color-change {
+  0% { background-color: $text-gray; }
+  50% { background-color: $gray; }
+  100% { background-color: $text-gray; }
+}
+
+@keyframes background-color-change {
+  0% { background-color: $text-gray; }
+  50% { background-color: $gray; }
+  100% { background-color: $text-gray; }
+}


### PR DESCRIPTION
Purpose
---------------
Feature
[https://www.pivotaltracker.com/story/show/179073406](url)

Solution
---------------
As a user, I want to see that my post or reply is loading after I post it.  create gray loading placeholder post/reply.


Change summary
---------------
* keep track of new post loading, new reply loading, and reply parent in the redux store
* create Blank Post and Blank Reply
* display the two above components based on the above redux state

Steps to Verify
----------------
1. create a post
2. create a reply
3. have multiple posts and multiple replies

Additional details / screenshot
----------------
*** Does this work if multiple people are posting are once?

https://user-images.githubusercontent.com/43625033/129978702-da5db0b6-becf-41b6-9e8c-069021f319ac.mov


