### PR TITLE
save profiles

### DIFF
--- a/src/components/ConnectionsListProfiles.tsx
+++ b/src/components/ConnectionsListProfiles.tsx
@@ -34,7 +34,7 @@ const ConnectionsListProfiles = ({
 
   const profileForId = (userId: DSNPUserId): Profile =>
     profiles[userId] || {
-      ...createProfile({ name: "Annonymous" }),
+      ...createProfile({ name: "Anonymous" }),
       contentHash: "",
       url: "",
       announcementType: AnnouncementType.Profile,

--- a/src/components/Profile.tsx
+++ b/src/components/Profile.tsx
@@ -46,14 +46,13 @@ const Profile = (): JSX.Element => {
   };
 
   const saveEditProfile = async () => {
-    if (userId !== undefined && newName !== undefined) {
-      const newProfile = core.activityContent.createProfile({
-        name: newName,
-        icon: profile?.icon,
-      });
-      await saveProfile(userId, newProfile);
-    }
     setIsEditing(!isEditing);
+    if (userId === undefined || newName === undefined) return;
+    const newProfile = core.activityContent.createProfile({
+      name: newName,
+      icon: profile?.icon,
+    });
+    await saveProfile(userId, newProfile);
   };
 
   const cancelEditProfile = () => {

--- a/src/components/Profile.tsx
+++ b/src/components/Profile.tsx
@@ -5,6 +5,8 @@ import React, { useEffect, useState } from "react";
 import { useAppSelector } from "../redux/hooks";
 import * as types from "../utilities/types";
 import { DSNPUserId } from "@dsnp/sdk/dist/types/core/identifiers";
+import { saveProfile } from "../services/sdk";
+import { core } from "@dsnp/sdk";
 
 const Profile = (): JSX.Element => {
   const userId: DSNPUserId | undefined = useAppSelector(
@@ -19,8 +21,8 @@ const Profile = (): JSX.Element => {
     : undefined;
 
   const handle = profile?.handle;
-  const [newName, setNewName] = useState<string | null>(null);
-  const [newHandle, setNewHandle] = useState<string | null>(null);
+  const [newName, setNewName] = useState<string | undefined>();
+  const [newHandle, setNewHandle] = useState<string | undefined>();
   const [didEditProfile, setDidEditProfile] = useState<boolean>(false);
 
   const profileName = profile?.name || "Anonymous";
@@ -43,15 +45,21 @@ const Profile = (): JSX.Element => {
       : `ProfileBlock__${sectionName}`;
   };
 
-  const saveEditProfile = () => {
-    //this is where we write to the blockchain
+  const saveEditProfile = async () => {
+    if (userId !== undefined && newName !== undefined) {
+      const newProfile = core.activityContent.createProfile({
+        name: newName,
+        icon: profile?.icon,
+      });
+      await saveProfile(userId, newProfile);
+    }
     setIsEditing(!isEditing);
   };
 
   const cancelEditProfile = () => {
     setIsEditing(!isEditing);
-    setNewName(null);
-    setNewHandle(null);
+    setNewName(undefined);
+    setNewHandle(undefined);
   };
 
   return (
@@ -98,16 +106,16 @@ const Profile = (): JSX.Element => {
           />
           <label className="ProfileBlock__personalInfoLabel">HANDLE</label>
           <input
-            className={getClassName("handle")}
+            className="ProfileBlock__handle"
             value={newHandle || newHandle === "" ? newHandle : handle}
             onChange={(e) => setNewHandle(e.target.value)}
-            disabled={!isEditing}
+            disabled={true}
           />
           <label className="ProfileBlock__personalInfoLabel">
             SOCIAL ADDRESS
           </label>
           <input
-            className={getClassName("dsnpUserId")}
+            className="ProfileBlock__dsnpUserId"
             value={profile?.fromId || "Anonymous"}
             disabled={true}
           />

--- a/src/components/test/ConnectionsListProfiles.test.tsx
+++ b/src/components/test/ConnectionsListProfiles.test.tsx
@@ -14,16 +14,17 @@ const mockUserList = [
   preFabProfiles[1],
   preFabProfiles[2],
   preFabProfiles[3],
+  preFabProfiles[4],
 ];
 
 const profiles = mockUserList.reduce((m, p) => ({ ...m, [p.fromId]: p }), {});
 
 const following = mockUserList
-  .slice(0, 2)
+  .slice(0, 3)
   .reduce((m, p) => ({ ...m, [p.fromId]: true }), {});
 
 const followers = mockUserList
-  .slice(1)
+  .slice(2)
   .reduce((m, p) => ({ ...m, [p.fromId]: true }), {});
 
 const store = {
@@ -68,7 +69,7 @@ describe("ConnectionsListProfiles", () => {
         })
       );
       expect(component.find(".ConnectionsListProfiles__profile").length).toBe(
-        2
+        Object.keys(following).length
       );
       expect(
         component.find(".ConnectionsListProfiles__name").first().text()
@@ -76,6 +77,9 @@ describe("ConnectionsListProfiles", () => {
       expect(
         component.find(".ConnectionsListProfiles__name").at(1).text()
       ).toContain(mockUserList[1].name);
+      expect(
+        component.find(".ConnectionsListProfiles__name").at(2).text()
+      ).toContain(mockUserList[2].name);
     });
 
     it("all connections can be unfollowed", () => {
@@ -92,6 +96,9 @@ describe("ConnectionsListProfiles", () => {
       expect(
         component.find(".ConnectionsListProfiles__button").at(1).text()
       ).toContain("Unfollow");
+      expect(
+        component.find(".ConnectionsListProfiles__button").at(2).text()
+      ).toContain("Unfollow");
     });
   });
 
@@ -105,17 +112,17 @@ describe("ConnectionsListProfiles", () => {
         })
       );
       expect(component.find(".ConnectionsListProfiles__profile").length).toBe(
-        3
+        Object.keys(followers).length
       );
       expect(
         component.find(".ConnectionsListProfiles__name").first().text()
-      ).toContain(mockUserList[1].name);
-      expect(
-        component.find(".ConnectionsListProfiles__name").at(1).text()
       ).toContain(mockUserList[2].name);
       expect(
-        component.find(".ConnectionsListProfiles__name").at(2).text()
+        component.find(".ConnectionsListProfiles__name").at(1).text()
       ).toContain(mockUserList[3].name);
+      expect(
+        component.find(".ConnectionsListProfiles__name").at(2).text()
+      ).toContain(mockUserList[4].name);
     });
 
     it("all followers can be followed or unfollowed depending on status", () => {

--- a/src/components/test/ProfileBlock.test.tsx
+++ b/src/components/test/ProfileBlock.test.tsx
@@ -44,9 +44,6 @@ describe("Profile Block", () => {
       expect(component.find(".ProfileBlock__name").props().disabled).toEqual(
         false
       );
-      expect(component.find(".ProfileBlock__handle").props().disabled).toEqual(
-        false
-      );
     });
   });
 

--- a/src/redux/slices/profileSlice.ts
+++ b/src/redux/slices/profileSlice.ts
@@ -9,6 +9,16 @@ const initialState: profileState = {
   profiles: {},
 };
 
+const latestProfile = (existing: Profile, current: Profile): Profile => {
+  if (!existing || existing.blockNumber === undefined) return current;
+  if (current.blockNumber !== existing.blockNumber) {
+    return current.blockNumber > existing.blockNumber ? current : existing;
+  } else if (current.blockIndex !== existing.blockIndex) {
+    return current.blockIndex > existing.blockIndex ? current : existing;
+  }
+  return current.batchIndex > existing.batchIndex ? current : existing;
+};
+
 export const profileSlice = createSlice({
   name: "profiles",
   initialState,
@@ -19,7 +29,12 @@ export const profileSlice = createSlice({
       const newProfile = oldProfile
         ? { ...oldProfile, ...action.payload }
         : action.payload;
-      return { profiles: { ...state.profiles, [key]: newProfile } };
+      return {
+        profiles: {
+          ...state.profiles,
+          [key]: latestProfile(oldProfile, newProfile),
+        },
+      };
     },
     removeProfile: (state, action: PayloadAction<HexString>) => {
       const { [action.payload]: _, ...newProfiles } = state.profiles;

--- a/src/redux/slices/profileSlice.ts
+++ b/src/redux/slices/profileSlice.ts
@@ -9,14 +9,16 @@ const initialState: profileState = {
   profiles: {},
 };
 
-const latestProfile = (existing: Profile, current: Profile): Profile => {
-  if (!existing || existing.blockNumber === undefined) return current;
-  if (current.blockNumber !== existing.blockNumber) {
-    return current.blockNumber > existing.blockNumber ? current : existing;
-  } else if (current.blockIndex !== existing.blockIndex) {
-    return current.blockIndex > existing.blockIndex ? current : existing;
+// choose latest profile comparing by blockNumber then blockIndex then batchIndex
+const latestProfile = (a: Profile, b: Profile): Profile => {
+  if (!a || a.blockNumber === undefined) return b;
+  if (!b || b.blockNumber === undefined) return a;
+  if (b.blockNumber !== a.blockNumber) {
+    return b.blockNumber > a.blockNumber ? b : a;
+  } else if (b.blockIndex !== a.blockIndex) {
+    return b.blockIndex > a.blockIndex ? b : a;
   }
-  return current.batchIndex > existing.batchIndex ? current : existing;
+  return b.batchIndex > a.batchIndex ? b : a;
 };
 
 export const profileSlice = createSlice({

--- a/src/test/testGraphs.ts
+++ b/src/test/testGraphs.ts
@@ -2,6 +2,12 @@ import { DSNPUserId } from "@dsnp/sdk/dist/types/core/identifiers";
 import { HexString } from "../utilities/types";
 import { generateDsnpUserId, getPrefabDsnpUserId } from "./testAddresses";
 
+/**
+ * Unidirectional lookup of graph realationships.
+ * For example, this structure can store all follow relationships
+ * for all users. The existence of a relationship from account1 to
+ * account2 can be checked with graph[account1]?.[account2].
+ */
 type Graph = Record<DSNPUserId, Record<DSNPUserId, boolean>>;
 
 interface SocialGraph {
@@ -16,6 +22,7 @@ export const generateRandomGraph = (
   return {};
 };
 
+// Invert a map from followers to followees into a map of followees to followers.
 const followersFromFollowing = (following: Graph): Graph => {
   const followers: Record<string, Record<string, boolean>> = {};
   for (const follower of Object.keys(following)) {

--- a/src/utilities/types.d.ts
+++ b/src/utilities/types.d.ts
@@ -13,7 +13,7 @@ export interface GraphChange {
 
 // ## Profile ##
 export type Profile = ProfileAnnouncement &
-  ActivityContentProfile & { handle: string };
+  ActivityContentProfile & { handle: string, blockNumber: number, blockIndex: number, batchIndex: number };
 
 // ## FeedItem ##
 export type FeedItem = BroadcastAnnouncement & ActivityContentNote;


### PR DESCRIPTION
Purpose
---------------
When we edit a profile, we want to actually send the change out to the DSNP network so others know about it and the change is persisted.

Solution
---------------
This PR wires the edit profile functionality to a new SDK method that creates and publishes a new profile.


Change summary
---------------
* Create `sdk.saveProfile` method (with some sdk refactoring to reduce redundancy).
* Wire the Profile edit functionality to call the save profile.
* Track blockNumber, blockIndex and batchIndex, so we can correctly order profile changes.
* Add comparison logic in the profile slice of the redux store to ensure we always show the latest profile.
* Address some feedback that came in late from #58.

Steps to Verify
----------------
1. Set up the app with the usual steps.
2. Start the app.
3. Log in.
4. Hit the edit button in the profile section.
5. Change the name.
6. Expect to sign a transaction.
7. Wait for the transaction to clear.
8. Expect every instance of your name in the feeds to be updated to the new value.
9. Reload the page.
10. Expect the name to be updated in the profile section.
