### PR TITLE
fix(feed): remove duplicate post

### DIFF
--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -1,16 +1,48 @@
 import React from "react";
 import App from "./App";
+import * as wallet from "../src/services/wallets/wallet";
+
 import { mount } from "enzyme";
 import { componentWithStore, createMockStore } from "./test/testhelpers";
+import * as sdk from "./services/sdk";
+import * as hooks from "./redux/hooks";
 
 jest.mock("../src/components/Header", () => () => <div> Header </div>);
 jest.mock("../src/components/Feed", () => () => <div> Feed </div>);
 jest.mock("../src/components/ProfileBlock", () => () => <div> Profile </div>);
 
-it("renders without crashing", () => {
-  const initialState = { user: {} };
+describe("App", () => {
+  const initialState = { user: { walletType: "METAMASK" }, feed: { feed: [] } };
   const store = createMockStore(initialState);
-  expect(() => {
-    mount(componentWithStore(App, store));
-  }).not.toThrow();
+
+  jest
+    .spyOn(wallet, "wallet")
+    .mockReturnValue({ reload: jest.fn().mockResolvedValue(null) } as any);
+
+  jest.spyOn(sdk, "setupProvider").mockReturnValue(undefined);
+
+  describe("useEffect", () => {
+    let unsubscribeFnc: unknown;
+    let component: any;
+
+    beforeEach(async () => {
+      const dispatch = jest.fn();
+      unsubscribeFnc = jest.fn();
+
+      jest.spyOn(React, "useEffect").mockImplementation((cb) => cb());
+      jest.spyOn(sdk, "startSubscriptions");
+      jest.spyOn(sdk, "setupProvider").mockReturnValue(undefined);
+      jest.spyOn(hooks, "useAppDispatch").mockReturnValue(dispatch);
+
+      dispatch.mockResolvedValue({ unsubscribeFnc });
+
+      component = await mount(componentWithStore(App, store));
+    });
+
+    it("calls clean up function", () => {
+      component.unmount();
+
+      expect(unsubscribeFnc).toHaveBeenCalled();
+    });
+  });
 });

--- a/src/services/sdk.ts
+++ b/src/services/sdk.ts
@@ -111,15 +111,15 @@ export const saveProfile = async (
   await batchAnnouncement(hash, announcement);
 };
 
-export const startPostSubscription = (
+export const startSubscriptions = async (
   dispatch: ThunkDispatch<any, Record<string, any>, AnyAction>
-): void => {
+): Promise<Record<string, any>> => {
   dispatch(clearFeedItems());
 
   // subscribe to all announcements
   let blockNumber: number;
   let blockIndex = 0;
-  core.contracts.subscription.subscribeToBatchPublications(
+  const unsubscribeToBatchPublications = core.contracts.subscription.subscribeToBatchPublications(
     (announcement: BatchPublicationLogData) => {
       if (announcement.blockNumber !== blockNumber) {
         blockNumber = announcement.blockNumber;
@@ -135,12 +135,17 @@ export const startPostSubscription = (
   );
 
   // subscribe to registry events
-  core.contracts.subscription.subscribeToRegistryUpdates(
+  const unsubscribeToRegistryUpdate = await core.contracts.subscription.subscribeToRegistryUpdates(
     handleRegistryUpdate(dispatch),
     {
       fromBlock: 1,
     }
   );
+
+  return {
+    unsubscribeToRegistryUpdate,
+    unsubscribeToBatchPublications,
+  };
 };
 
 export const setupProvider = (walletType: WalletType): void => {


### PR DESCRIPTION
Ensure that feed does not display unwanted duplicate post.

After creating a post, feed shows duplicates.
This happens when attempting to create a post
after re-login into account.

The cause of this behavior was a result of
not unsubscribing to events when app page
gets unmounted.
