### PR TITLE
fix problem with subscriptions + test

### DIFF
--- a/src/services/sdk.test.ts
+++ b/src/services/sdk.test.ts
@@ -1,0 +1,35 @@
+import { startSubscriptions } from "./sdk";
+import { core } from "@dsnp/sdk";
+import { flushPromises } from "../test/testhelpers";
+const subscription = core.contracts.subscription;
+
+const mockThunkDispatch = jest.fn;
+
+describe("sdk.ts", () => {
+  describe("startSubscriptions", () => {
+    it("works", async () => {
+      let caught = "";
+      const batchSub = jest
+        .spyOn(subscription, "subscribeToBatchPublications")
+        .mockImplementation(async () => jest.fn());
+
+      const regSub = jest
+        .spyOn(subscription, "subscribeToRegistryUpdates")
+        .mockImplementation(async () => jest.fn);
+
+      const res = await startSubscriptions(mockThunkDispatch);
+      const unsub = () =>
+        Object.values(res).forEach(async (u) => {
+          try {
+            await u();
+          } catch (e) {
+            caught = e.message;
+          }
+        });
+      await expect(unsub).not.toThrow();
+      expect(batchSub).toHaveBeenCalled();
+      expect(regSub).toHaveBeenCalled();
+      expect(caught).toEqual("");
+    });
+  });
+});

--- a/src/services/sdk.test.ts
+++ b/src/services/sdk.test.ts
@@ -1,6 +1,5 @@
 import { startSubscriptions } from "./sdk";
 import { core } from "@dsnp/sdk";
-import { flushPromises } from "../test/testhelpers";
 const subscription = core.contracts.subscription;
 
 const mockThunkDispatch = jest.fn;

--- a/src/services/sdk.ts
+++ b/src/services/sdk.ts
@@ -119,7 +119,7 @@ export const startSubscriptions = async (
   // subscribe to all announcements
   let blockNumber: number;
   let blockIndex = 0;
-  const unsubscribeToBatchPublications = core.contracts.subscription.subscribeToBatchPublications(
+  const unsubscribeToBatchPublications = await core.contracts.subscription.subscribeToBatchPublications(
     (announcement: BatchPublicationLogData) => {
       if (announcement.blockNumber !== blockNumber) {
         blockNumber = announcement.blockNumber;


### PR DESCRIPTION
## Purpose
Logging out was broken because on subscribing to batch publications we should have been `await`ing the result. So when we went to unsub it would throw because the result was a Promise and not a function.

[Fixes #179292977](https://www.pivotaltracker.com/story/show/179292977)

Solution
---------------
SUPER short fix, annoyingly tedious to construct regression test that shows the red/green behavior.

Steps to Verify
----------------
1.  Tests should all pass
1.  If you remove the "await" from the call to `core.contracts.subscription.subscribeToBatchPublications`, the test should fail.
1.  You should be able to logout without exception now.
