### PR TITLE
fix inconsistent ordering of posts

### DIFF
--- a/src/components/PostList.tsx
+++ b/src/components/PostList.tsx
@@ -31,7 +31,9 @@ const PostList = ({ feedType }: PostListProps): JSX.Element => {
     (state) => (userId ? state.graphs.following[userId] : undefined) || {}
   );
 
-  const initialFeed: FeedItem[] = useAppSelector((state) => state.feed.feedItems).filter(
+  const initialFeed: FeedItem[] = useAppSelector(
+    (state) => state.feed.feedItems
+  ).filter(
     (post) => post?.content?.type === "Note" && post?.inReplyTo === undefined
   );
   const loading: boolean = useAppSelector(

--- a/src/components/PostList.tsx
+++ b/src/components/PostList.tsx
@@ -15,6 +15,14 @@ interface PostListProps {
   feedType: FeedTypes;
 }
 
+const sortFeed = (feed: FeedItem[]): FeedItem[] => {
+  feed.sort(
+    (firstFeedItem: FeedItem, secondFeedItem: FeedItem) =>
+      secondFeedItem.blockNumber - firstFeedItem.blockNumber
+  );
+  return feed;
+};
+
 const PostList = ({ feedType }: PostListProps): JSX.Element => {
   const userId: DSNPUserId | undefined = useAppSelector(
     (state) => state.user.id
@@ -22,12 +30,15 @@ const PostList = ({ feedType }: PostListProps): JSX.Element => {
   const myGraph: Record<DSNPUserId, boolean> = useAppSelector(
     (state) => (userId ? state.graphs.following[userId] : undefined) || {}
   );
-  const feed: FeedItem[] = useAppSelector((state) => state.feed.feed).filter(
+
+  const initialFeed: FeedItem[] = useAppSelector((state) => state.feed.feedItems).filter(
     (post) => post?.content?.type === "Note" && post?.inReplyTo === undefined
   );
   const loading: boolean = useAppSelector(
     (state) => state.feed.isPostLoading.loading
   );
+
+  const feed: FeedItem[] = sortFeed(initialFeed);
 
   let currentFeed: FeedItem[] = [];
 
@@ -46,12 +57,9 @@ const PostList = ({ feedType }: PostListProps): JSX.Element => {
       {loading && <BlankPost />}
       {currentFeed.length > 0 ? (
         <>
-          {currentFeed
-            .slice(0)
-            .reverse()
-            .map((post, index) => (
-              <Post key={index} feedItem={post} />
-            ))}
+          {currentFeed.map((post, index) => (
+            <Post key={index} feedItem={post} />
+          ))}
         </>
       ) : (
         "Empty Feed!"

--- a/src/components/ReplyBlock.tsx
+++ b/src/components/ReplyBlock.tsx
@@ -16,7 +16,7 @@ interface ReplyBlockProps {
 
 const ReplyBlock = ({ parent }: ReplyBlockProps): JSX.Element => {
   const replyFeed: FeedItem[] = useAppSelector(
-    (state) => state.feed.feed
+    (state) => state.feed.feedItems
   ).filter((reply) => {
     return reply?.content?.type === "Note" && reply?.inReplyTo === parent;
   }) as FeedItem[];

--- a/src/components/test/Feed.test.tsx
+++ b/src/components/test/Feed.test.tsx
@@ -7,12 +7,12 @@ import { getPreFabSocialGraph } from "../../test/testGraphs";
 import { getPrefabProfile } from "../../test/testProfiles";
 
 const userId = getPrefabProfile(0).fromId;
-const feed = getPrefabFeed();
+const feedItems = getPrefabFeed();
 const graphs = getPreFabSocialGraph();
 const initialState = {
   user: { id: userId },
   feed: {
-    feed: feed,
+    feedItems: feedItems,
     isPostLoading: { loading: false, myIdentifier: undefined },
     isReplyLoading: { loading: false, parent: undefined },
   },
@@ -36,7 +36,7 @@ describe("Feed", () => {
     const initialState = {
       user: {},
       feed: {
-        feed: feed,
+        feedItems,
         isPostLoading: { loading: false, myIdentifier: undefined },
         isReplyLoading: { loading: false, parent: undefined },
       },

--- a/src/components/test/PostList.test.tsx
+++ b/src/components/test/PostList.test.tsx
@@ -1,14 +1,87 @@
 import PostList from "../PostList";
-import { shallow } from "enzyme";
+import { mount, shallow } from "enzyme";
 import { componentWithStore, createMockStore } from "../../test/testhelpers";
-import { getPrefabFeed } from "../../test/testFeeds";
+import { generateFeedItem, getPrefabFeed } from "../../test/testFeeds";
+import { ActivityContentNote } from "@dsnp/sdk/dist/types/core/activityContent";
+import { FeedItem } from "../../utilities/types";
+import Login from "../Login";
+import * as wallet from "../../services/wallets/wallet";
+import { getPrefabDsnpUserId } from "../../test/testAddresses";
+import { getPrefabProfile } from "../../test/testProfiles";
+import { getPreFabSocialGraph } from "../../test/testGraphs";
 
-const store = createMockStore({ feed: getPrefabFeed });
+let initialBlockNumber = 0;
+const feed = getPrefabFeed();
+feed.forEach((feedItem) => {
+  feedItem.blockNumber = initialBlockNumber++;
+});
 
+let store = createMockStore({ feed: feed });
 describe("PostList", () => {
   it("renders without crashing", () => {
     expect(() => {
       shallow(componentWithStore(PostList, store));
     }).not.toThrow();
+  });
+
+  describe("when feed items are returned out of order", () => {
+    it("renders feed items in the correct order", () => {
+      const address1 = getPrefabDsnpUserId(0);
+      const address2 = getPrefabDsnpUserId(1);
+      const address3 = getPrefabDsnpUserId(2);
+
+      const feedItem1: FeedItem = generateFeedItem(
+        address1,
+        {
+          type: "Note",
+          mediaType: "text/plain",
+          content: "hello hello",
+        } as ActivityContentNote,
+        true
+      );
+      feedItem1.blockNumber = 1;
+
+      const feedItem2: FeedItem = generateFeedItem(
+        address2,
+        {
+          type: "Note",
+          mediaType: "text/plain",
+          content: "hi there",
+        } as ActivityContentNote,
+        true
+      );
+      feedItem2.blockNumber = 2;
+
+      const feedItem3: FeedItem = generateFeedItem(
+        address3,
+        {
+          type: "Note",
+          mediaType: "text/plain",
+          content: "Goodbye",
+        } as ActivityContentNote,
+        true
+      );
+
+      feedItem3.blockNumber = 3;
+
+      const feed: FeedItem[] = [feedItem2, feedItem1, feedItem3];
+      const graphs = getPreFabSocialGraph();
+      const userId = getPrefabProfile(0).fromId;
+      store = createMockStore({
+        feed: { feedItems: feed, isPostLoading: { loading: false} },
+        user: { id: userId },
+        graphs: graphs,
+      });
+
+      const component = mount(componentWithStore(PostList, store));
+
+      expect(component.find(".Post__caption").first().text()).toContain(
+        "Goodbye"
+      );
+
+      expect(component.find(".Post__caption").last().text()).toContain(
+        "hello hello"
+      );
+    });
   });
 });

--- a/src/components/test/PostList.test.tsx
+++ b/src/components/test/PostList.test.tsx
@@ -4,8 +4,6 @@ import { componentWithStore, createMockStore } from "../../test/testhelpers";
 import { generateFeedItem, getPrefabFeed } from "../../test/testFeeds";
 import { ActivityContentNote } from "@dsnp/sdk/dist/types/core/activityContent";
 import { FeedItem } from "../../utilities/types";
-import Login from "../Login";
-import * as wallet from "../../services/wallets/wallet";
 import { getPrefabDsnpUserId } from "../../test/testAddresses";
 import { getPrefabProfile } from "../../test/testProfiles";
 import { getPreFabSocialGraph } from "../../test/testGraphs";
@@ -68,7 +66,7 @@ describe("PostList", () => {
       const graphs = getPreFabSocialGraph();
       const userId = getPrefabProfile(0).fromId;
       store = createMockStore({
-        feed: { feedItems: feed, isPostLoading: { loading: false} },
+        feed: { feedItems: feed, isPostLoading: { loading: false } },
         user: { id: userId },
         graphs: graphs,
       });

--- a/src/components/test/ReplyBlock.test.tsx
+++ b/src/components/test/ReplyBlock.test.tsx
@@ -6,8 +6,8 @@ import { getPrefabFeed } from "../../test/testFeeds";
 import { waitFor } from "@testing-library/react";
 import * as sdk from "../../services/sdk";
 
-const feed = getPrefabFeed();
-const initialState = { user: { id: "0x0345" }, feed: { feed } };
+const feedItems = getPrefabFeed();
+const initialState = { user: { id: "0x0345" }, feed: { feedItems } };
 const store = createMockStore(initialState);
 
 const writeReply = async (component: any) => {

--- a/src/redux/slices/feedSlice.ts
+++ b/src/redux/slices/feedSlice.ts
@@ -12,13 +12,13 @@ interface isReplyLoadingType {
 }
 
 interface feedState {
-  feed: FeedItem[];
+  feedItems: FeedItem[];
   isPostLoading: isPostLoadingType;
   isReplyLoading: isReplyLoadingType;
 }
 
 const initialState: feedState = {
-  feed: [],
+  feedItems: [],
   isPostLoading: { loading: false, currentUserId: undefined },
   isReplyLoading: { loading: false, parent: undefined },
 };
@@ -34,27 +34,16 @@ export const feedSlice = createSlice({
         // arrives while waiting for the current user's to appear.
         return {
           ...state,
-          feed: [...state.feed, newFeedItem],
+          feedItems: [...state.feedItems, newFeedItem],
           isPostLoading: { loading: false, currentUserId: undefined },
           isReplyLoading: { loading: false, parent: undefined },
         };
       }
-      return {
-        ...state,
-        feed: [...state.feed, newFeedItem],
-      };
-    },
-    addFeedItems: (state, action: PayloadAction<FeedItem[]>) => {
-      const newFeedItems = action.payload;
-      return {
-        ...state,
-        feed: [...state.feed, ...newFeedItems],
-      };
     },
     clearFeedItems: (state) => {
       return {
         ...state,
-        feed: [],
+        feedItems: [],
       };
     },
     postLoading: (state, isLoading: PayloadAction<isPostLoadingType>) => {
@@ -77,11 +66,12 @@ export const feedSlice = createSlice({
     },
   },
 });
+
 export const {
   addFeedItem,
-  addFeedItems,
   clearFeedItems,
   postLoading,
   replyLoading,
 } = feedSlice.actions;
+
 export default feedSlice.reducer;


### PR DESCRIPTION
Purpose
---------------
[Pivotal Tracker Story #179276259](https://www.pivotaltracker.com/story/show/179276259)
Our posts were not being rendered in the correct order. This is because our call to retrieve activity pub content and send it to redux is async. This means content of posts is not always stored in redux in the same order that it is stored on chain. 

Solution
---------------
Before rendering posts we need to sort them by block number to ensure that they are in the correct order. 

Change summary
---------------
* Add a function to `PostList.tsx` to ensure that posts are ordered.
* rename `feed` to `feedItems` so that we are not referring to `state.feed.feed` but rather state.feed.feedItems
* Add tests
