### PR TITLE
fix feed loading

### DIFF
--- a/src/redux/slices/feedSlice.ts
+++ b/src/redux/slices/feedSlice.ts
@@ -23,22 +23,36 @@ const initialState: feedState = {
   isReplyLoading: { loading: false, parent: undefined },
 };
 
+const newPostLoadingState = (
+  state: isPostLoadingType,
+  item: FeedItem
+): isPostLoadingType => {
+  if (!state.loading || state.currentUserId === item.fromId)
+    return { loading: false, currentUserId: undefined };
+  return state;
+};
+
+const newReplyLoadingState = (
+  state: isReplyLoadingType,
+  item: FeedItem
+): isReplyLoadingType => {
+  if (!state.loading || state.parent === item.parent)
+    return { loading: false, parent: undefined };
+  return state;
+};
+
 export const feedSlice = createSlice({
   name: "feed",
   initialState,
   reducers: {
     addFeedItem: (state, action: PayloadAction<FeedItem>) => {
       const newFeedItem = action.payload;
-      if (state.isPostLoading.currentUserId === newFeedItem.fromId) {
-        // to keep loading from being turned off when some else's post
-        // arrives while waiting for the current user's to appear.
-        return {
-          ...state,
-          feedItems: [...state.feedItems, newFeedItem],
-          isPostLoading: { loading: false, currentUserId: undefined },
-          isReplyLoading: { loading: false, parent: undefined },
-        };
-      }
+      return {
+        ...state,
+        feedItems: [...state.feedItems, newFeedItem],
+        isPostLoading: newPostLoadingState(state.isPostLoading, newFeedItem),
+        isReplyLoading: newReplyLoadingState(state.isReplyLoading, newFeedItem),
+      };
     },
     clearFeedItems: (state) => {
       return {

--- a/src/redux/slices/feedSlice.ts
+++ b/src/redux/slices/feedSlice.ts
@@ -27,7 +27,7 @@ const newPostLoadingState = (
   state: isPostLoadingType,
   item: FeedItem
 ): isPostLoadingType => {
-  if (!state.loading || state.currentUserId === item.fromId)
+  if (state.loading && state.currentUserId === item.fromId)
     return { loading: false, currentUserId: undefined };
   return state;
 };
@@ -36,8 +36,9 @@ const newReplyLoadingState = (
   state: isReplyLoadingType,
   item: FeedItem
 ): isReplyLoadingType => {
-  if (!state.loading || state.parent === item.parent)
+  if (state.loading && state.parent === item.inReplyTo) {
     return { loading: false, parent: undefined };
+  }
   return state;
 };
 


### PR DESCRIPTION
Purpose
---------------
A bug was introduced into the feed reducer that prevented all existing feed items from entering redux state and displaying in the feed. This PR attempts to keep the spirit of the erroneous code with limiting the posts.

Solution
---------------
A condition was added in the feed reducer that prevented the item from being added to the store if it did not match other state set by the NewPost component. This would reject all posts from other people in order to avoid the wrong posts changing the loading state. This PR limits this condition only to the loading state and allows all posts into state.


Change summary
---------------
* Remove `(state.isPostLoading.currentUserId === newFeedItem.fromId)` clause.
* Replace with `newPostLoadingState` and `newReplyLoadingState`


Steps to Verify
----------------
1. Start up app with a populated feed.
2. Existing posts appear
