### PR TITLE
EC: On clean start, nothing in Feed 

### DIFF
--- a/src/components/Login.tsx
+++ b/src/components/Login.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import { Badge, Button } from "antd";
 import { WalletOutlined } from "@ant-design/icons";
 import { useAppDispatch, useAppSelector } from "../redux/hooks";
-import { userLogin, userLogout } from "../redux/slices/userSlice";
+import { userLogout, userUpdateId } from "../redux/slices/userSlice";
 import * as sdk from "../services/sdk";
 import * as wallet from "../services/wallets/wallet";
 import * as session from "../services/session";
@@ -23,47 +23,35 @@ const Login = ({ loginWalletOptions }: LoginProps): JSX.Element => {
   );
 
   const [walletAddress, setWalletAddress] = React.useState<string>("");
-  const [walletType, setWalletType] = React.useState<wallet.WalletType>(
-    loginWalletOptions || wallet.WalletType.NONE
-  );
   const [registrations, setRegistrations] = React.useState<Registration[]>([]);
 
   const dispatch = useAppDispatch();
   const userId = useAppSelector((state) => state.user.id);
+  const currentWalletType = useAppSelector((state) => state.user.walletType);
 
-  const setLoginAndSession = (fromURI: string) => {
+  const setUserID = (fromURI: string) => {
     const fromId = core.identifiers.convertDSNPUserURIToDSNPUserId(fromURI);
+    dispatch(userUpdateId(fromId));
+    session.upsertSessionUserId(fromId);
     setRegistrationVisible(false);
-    dispatch(userLogin({ id: fromId, walletType }));
-    session.saveSession({ id: fromId, walletType });
   };
 
-  const resetLoginAndSession = () => {
-    setRegistrationVisible(false);
-    setWalletAddress("");
-    setWalletType(wallet.WalletType.NONE);
-    session.saveSession({ id: undefined, walletType });
-  };
-
-  const login = async (walletType: wallet.WalletType) => {
+  const login = async (selectedType: wallet.WalletType) => {
     if (loading) return;
     startLoading(true);
-    setWalletType(walletType);
     try {
-      const waddr = await wallet.wallet(walletType).login();
+      const waddr = await wallet.wallet(selectedType).login();
       setWalletAddress(waddr);
-      sdk.setupProvider(walletType);
+      sdk.setupProvider(selectedType);
       const registrations = await sdk.getSocialIdentities(waddr);
-
       if (registrations.length === 1) {
-        setLoginAndSession(registrations[0].dsnpUserURI);
+        setUserID(registrations[0].dsnpUserURI);
       } else {
-        dispatch(userLogin({ walletType: walletType }));
         setRegistrations(registrations);
         setRegistrationVisible(true);
       }
     } catch (error) {
-      resetLoginAndSession();
+      logout();
     } finally {
       setPopoverVisible(false);
       startLoading(false);
@@ -72,8 +60,11 @@ const Login = ({ loginWalletOptions }: LoginProps): JSX.Element => {
 
   const logout = () => {
     session.clearSession();
-    if (walletType !== wallet.WalletType.NONE)
-      wallet.wallet(walletType).logout();
+    setRegistrationVisible(false);
+    setWalletAddress("");
+    if (currentWalletType !== wallet.WalletType.NONE) {
+      wallet.wallet(currentWalletType).logout();
+    }
     dispatch(userLogout());
   };
 
@@ -83,7 +74,7 @@ const Login = ({ loginWalletOptions }: LoginProps): JSX.Element => {
         <RegistrationModal
           visible={registrationVisible}
           registrations={registrations}
-          onIdResolved={setLoginAndSession}
+          onIdResolved={setUserID}
           walletAddress={walletAddress}
         >
           <LoginButton
@@ -102,7 +93,7 @@ const Login = ({ loginWalletOptions }: LoginProps): JSX.Element => {
           >
             <img
               className="Login__walletIcon"
-              src={wallet.wallet(walletType).icon}
+              src={wallet.wallet(currentWalletType).icon}
               alt="Wallet Symbol"
             />
           </Badge>

--- a/src/components/LoginButton.tsx
+++ b/src/components/LoginButton.tsx
@@ -1,6 +1,9 @@
 import { Button, Popover, Spin } from "antd";
 import * as wallet from "../services/wallets/wallet";
 import React from "react";
+import { userUpdateWalletType } from "../redux/slices/userSlice";
+import { useAppDispatch } from "../redux/hooks";
+import { upsertSessionWalletType } from "../services/session";
 
 interface LoginButtonProps {
   popoverVisible: boolean;
@@ -21,6 +24,14 @@ const LoginButton = ({
     setPopoverVisible(visible);
   };
 
+  const dispatch = useAppDispatch();
+
+  const setWalletType = (wtype: wallet.WalletType) => {
+    dispatch(userUpdateWalletType(wtype));
+    upsertSessionWalletType(wtype);
+    loginWithWalletType(wtype);
+  };
+
   const HeaderLoginButton = (
     <Popover
       placement="bottomRight"
@@ -31,13 +42,13 @@ const LoginButton = ({
         <div className="LoginButton__loginOptions">
           <Button
             className="LoginButton__loginTorus"
-            onClick={() => loginWithWalletType(wallet.WalletType.TORUS)}
+            onClick={() => setWalletType(wallet.WalletType.TORUS)}
           >
             Torus
           </Button>
           <Button
             className="LoginButton__loginMetamask"
-            onClick={() => loginWithWalletType(wallet.WalletType.METAMASK)}
+            onClick={() => setWalletType(wallet.WalletType.METAMASK)}
           >
             MetaMask
           </Button>

--- a/src/components/test/Login.test.tsx
+++ b/src/components/test/Login.test.tsx
@@ -9,6 +9,7 @@ import {
 } from "../../test/testhelpers";
 import * as metamask from "../../services/wallets/metamask/metamask";
 import * as sdk from "../../services/sdk";
+import * as session from "../../services/session";
 
 let torusWallet: wallet.Wallet;
 let metamaskWallet: wallet.Wallet;
@@ -99,18 +100,22 @@ describe("Login Component", () => {
     });
 
     describe("when wallet type is passed to Login", () => {
+      const sessionSpy = jest.spyOn(session, "clearSession");
       describe("and it is set to Torus", () => {
+        initialState.user.walletType = wallet.WalletType.TORUS;
         const component = mount(
           componentWithStore(Login, store, {
             loginWalletOptions: wallet.WalletType.TORUS,
           })
         );
         it("renders logout and clicking on it calls torus logout", () => {
-          component.find("Button").simulate("click");
+          component.find("Button").first().simulate("click");
+          expect(sessionSpy).toHaveBeenCalled();
           expect(torus.logout).toHaveBeenCalled();
         });
       });
       describe("and it is set to Metamask", () => {
+        initialState.user.walletType = wallet.WalletType.METAMASK;
         const component = mount(
           componentWithStore(Login, store, {
             loginWalletOptions: wallet.WalletType.METAMASK,
@@ -118,6 +123,7 @@ describe("Login Component", () => {
         );
         it("renders logout and clicking on it calls metamask logout", () => {
           component.find("Button").simulate("click");
+          expect(sessionSpy).toHaveBeenCalled();
           expect(metamaskWallet.logout).toHaveBeenCalled();
         });
       });

--- a/src/redux/slices/userSlice.ts
+++ b/src/redux/slices/userSlice.ts
@@ -26,7 +26,19 @@ export const userSlice = createSlice({
       ...state,
       id: action.payload,
     }),
+    userUpdateWalletType: (
+      state,
+      action: PayloadAction<wallet.WalletType>
+    ) => ({
+      ...state,
+      walletType: action.payload,
+    }),
   },
 });
-export const { userLogin, userLogout, userUpdateId } = userSlice.actions;
+export const {
+  userLogin,
+  userLogout,
+  userUpdateId,
+  userUpdateWalletType,
+} = userSlice.actions;
 export default userSlice.reducer;

--- a/src/services/session.ts
+++ b/src/services/session.ts
@@ -6,6 +6,11 @@ interface SessionData {
   walletType: WalletType;
 }
 
+const saveSession = (sessionData: SessionData): SessionData => {
+  sessionStorage.setItem("session", JSON.stringify(sessionData));
+  return sessionData;
+};
+
 export const clearSession = (): void => {
   sessionStorage.removeItem("session");
 };
@@ -19,9 +24,21 @@ export const loadSession = (): SessionData | null => {
   }
 };
 
-export const saveSession = (sessionData: SessionData): SessionData => {
-  sessionStorage.setItem("session", JSON.stringify(sessionData));
-  return sessionData;
+export const upsertSessionWalletType = (wtype: WalletType): void => {
+  const curSession = loadSession() || {
+    id: undefined,
+    walletType: WalletType.NONE,
+  };
+
+  saveSession({ ...curSession, walletType: wtype });
+};
+
+export const upsertSessionUserId = (newId: DSNPUserId): void => {
+  const curSession = loadSession() || {
+    id: undefined,
+    walletType: WalletType.NONE,
+  };
+  saveSession({ ...curSession, id: newId });
 };
 
 export const hasSession = (): boolean => !!sessionStorage.getItem("session");


### PR DESCRIPTION
## Purpose
[Fixes #179294216](https://www.pivotaltracker.com/story/show/179294216).  If you open a browser and login you don't see the feed until you logout and back in.

## Solution
Simplify walletType storage and separate saving userID and walletType.
A side effect is that this kind of fixes [showing a feed without logging in](https://www.pivotaltracker.com/story/show/178789896), but it's not the prettiest way to do that.

## Change summary
* Eliminate storage of walletType in local state; store in redux + session.
* Make the LoginButton component responsible for updating wallet type, since that is where walletType is chosen.
* We still pass the chosen walletType back to login so there won't be a race condition - login needs the walletType to get the wallet Address.

**Notes**
* I tried/considered eliminating session storage of wallet type entirely, but if the user elects to keep sessions active when they quit their browser, then maybe they will want it.  If we don't care about that, I can take out session storage and it works fine. Since this is an example client, maybe we don't care about session storage at all?
* I tried to validate this in Torus but I could only get so far because I could not convince the hardhat node to let me send that account some localETH.

Steps to Verify
----------------
I have tested this on Firefox and Chrome, with a clean start, and then repeated logouts, with switching between unregistered and registered accounts, and partially with  Torus.  However it might benefit from someone else playing around with it.

