### PR TITLE
Bugs/render bugs and close registration popover

### DIFF
--- a/src/components/Login.tsx
+++ b/src/components/Login.tsx
@@ -75,6 +75,7 @@ const Login = ({ loginWalletOptions }: LoginProps): JSX.Element => {
           visible={registrationVisible}
           registrations={registrations}
           onIdResolved={setUserID}
+          onCancel={logout}
           walletAddress={walletAddress}
         >
           <LoginButton

--- a/src/components/Profile.tsx
+++ b/src/components/Profile.tsx
@@ -21,8 +21,8 @@ const Profile = (): JSX.Element => {
     : undefined;
 
   const handle = profile?.handle;
-  const [newName, setNewName] = useState<string>("");
-  const [newHandle, setNewHandle] = useState<string>("");
+  const [newName, setNewName] = useState<string | undefined>();
+  const [newHandle, setNewHandle] = useState<string | undefined>();
   const [didEditProfile, setDidEditProfile] = useState<boolean>(false);
 
   const profileName = profile?.name || "Anonymous";
@@ -57,8 +57,8 @@ const Profile = (): JSX.Element => {
 
   const cancelEditProfile = () => {
     setIsEditing(!isEditing);
-    setNewName("");
-    setNewHandle("");
+    setNewName(undefined);
+    setNewHandle(undefined);
   };
 
   return (
@@ -99,14 +99,14 @@ const Profile = (): JSX.Element => {
           <label className="ProfileBlock__personalInfoLabel">NAME</label>
           <input
             className={getClassName("name")}
-            value={newName !== "" ? newName : profileName}
+            value={newName || newName === "" ? newName : profileName}
             onChange={(e) => setNewName(e.target.value)}
             disabled={!isEditing}
           />
           <label className="ProfileBlock__personalInfoLabel">HANDLE</label>
           <input
             className="ProfileBlock__handle"
-            value={newHandle !== "" ? newHandle : handle}
+            value={newHandle || newHandle === "" ? newHandle : handle}
             onChange={(e) => setNewHandle(e.target.value)}
             disabled={true}
           />

--- a/src/components/Profile.tsx
+++ b/src/components/Profile.tsx
@@ -21,8 +21,8 @@ const Profile = (): JSX.Element => {
     : undefined;
 
   const handle = profile?.handle;
-  const [newName, setNewName] = useState<string | undefined>();
-  const [newHandle, setNewHandle] = useState<string | undefined>();
+  const [newName, setNewName] = useState<string>("");
+  const [newHandle, setNewHandle] = useState<string>("");
   const [didEditProfile, setDidEditProfile] = useState<boolean>(false);
 
   const profileName = profile?.name || "Anonymous";
@@ -57,8 +57,8 @@ const Profile = (): JSX.Element => {
 
   const cancelEditProfile = () => {
     setIsEditing(!isEditing);
-    setNewName(undefined);
-    setNewHandle(undefined);
+    setNewName("");
+    setNewHandle("");
   };
 
   return (
@@ -99,14 +99,14 @@ const Profile = (): JSX.Element => {
           <label className="ProfileBlock__personalInfoLabel">NAME</label>
           <input
             className={getClassName("name")}
-            value={newName || newName === "" ? newName : profileName}
+            value={newName !== "" ? newName : profileName}
             onChange={(e) => setNewName(e.target.value)}
             disabled={!isEditing}
           />
           <label className="ProfileBlock__personalInfoLabel">HANDLE</label>
           <input
             className="ProfileBlock__handle"
-            value={newHandle || newHandle === "" ? newHandle : handle}
+            value={newHandle !== "" ? newHandle : handle}
             onChange={(e) => setNewHandle(e.target.value)}
             disabled={true}
           />

--- a/src/components/RegistrationModal.tsx
+++ b/src/components/RegistrationModal.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from "react";
+import React from "react";
 import { Alert, Button, Form, Input, Popover } from "antd";
 import { useAppSelector } from "../redux/hooks";
 import UserAvatar from "./UserAvatar";
@@ -192,9 +192,13 @@ const RegistrationModal = ({
       visible={visible}
       content={
         <div className="RegistrationModal">
-          <a className="RegistrationModal__cancel" onClick={onCancel}>
+          <Button
+            type="link"
+            className="RegistrationModal__cancel"
+            onClick={onCancel}
+          >
             Cancel
-          </a>
+          </Button>
           <h2>Welcome!</h2>
           {isCreatingRegistration ? registerNewHandleForm : selectHandleContent}
         </div>

--- a/src/components/RegistrationModal.tsx
+++ b/src/components/RegistrationModal.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useEffect } from "react";
 import { Alert, Button, Form, Input, Popover } from "antd";
 import { useAppSelector } from "../redux/hooks";
 import UserAvatar from "./UserAvatar";
@@ -15,6 +15,7 @@ interface RegistrationModalProps {
   registrations: registry.Registration[];
   walletAddress: HexString;
   onIdResolved: (uri: DSNPUserURI) => void;
+  onCancel: () => void;
 }
 
 const RegistrationModal = ({
@@ -23,6 +24,7 @@ const RegistrationModal = ({
   registrations,
   walletAddress,
   onIdResolved,
+  onCancel,
 }: RegistrationModalProps): JSX.Element => {
   const [hasRegistrations, setHasRegistrations] = React.useState<boolean>(
     false
@@ -93,7 +95,11 @@ const RegistrationModal = ({
       }}
       onFinish={register}
     >
-      {registrationError && <Alert message={registrationError} type="error" />}
+      {registrationError && (
+        <>
+          <Alert message={registrationError} type="error" />
+        </>
+      )}
       <p>Please create a handle:</p>
       <Form.Item
         name="handle"
@@ -186,6 +192,9 @@ const RegistrationModal = ({
       visible={visible}
       content={
         <div className="RegistrationModal">
+          <a className="RegistrationModal__cancel" onClick={onCancel}>
+            Cancel
+          </a>
           <h2>Welcome!</h2>
           {isCreatingRegistration ? registerNewHandleForm : selectHandleContent}
         </div>

--- a/src/components/scss/RegistrationModal.scss
+++ b/src/components/scss/RegistrationModal.scss
@@ -65,8 +65,8 @@
   }
 
   .RegistrationModal__cancel {
-    display: flex;
-    flex-direction: row-reverse;
-    height: 10px;
+    color: $shadow-green;
+    position: absolute;
+    margin-left: 232px;
   }
 }

--- a/src/components/scss/RegistrationModal.scss
+++ b/src/components/scss/RegistrationModal.scss
@@ -63,4 +63,10 @@
   .ant-alert {
     margin-bottom: 1em;
   }
+
+  .RegistrationModal__cancel {
+    display: flex;
+    flex-direction: row-reverse;
+    height: 10px;
+  }
 }


### PR DESCRIPTION
Purpose
---------------
This fixes a couple of niggling things,
[Fixes #179382644](https://www.pivotaltracker.com/story/show/179382644)

* Puts a "cancel" link in the registration modal which does nothing but call `logout` which itself does the things you'd want to do on a cancel.  This was really bugging me because if there is a Metamask error or some other error when signing in, then you have to reload the entire page to start over
* Handles an uncaught Promise rejection in App.tsx, which occurs if you cancel Torus login.  I don't know why it throws, but it does, and either way you have to click the cancel "X" twice ([Bug filed](https://www.pivotaltracker.com/story/show/179382580)).   So we first check if all the user was doing was cancelling (Torus) login, and if so, just set the wallettype in redux & session to `NONE`, else log the error.

Solution
---------------
* Make a cancel link with styling and a handler that's passed through as a prop to RegistrationModal
* Put a try/catch in App.tsx to deal with Torus behavior

Steps to Verify
----------------
1. You can cancel Torus login and it doesn't throw
1. When you click Login with Metamask and you need to Register, you can cancel the registration, and the registration dialog is dismissed without prejudice.

Additional details / screenshot
----------------
Note the screenshot below is a little out of date - I fixed up the margins so it looks nicer now.  Also that offset/shadowing is in main, it's not a regression.
![Screen Shot 2021-08-26 at 5 18 41 PM](https://user-images.githubusercontent.com/502640/131052359-31a5f966-ec2f-4750-90e1-435d365ef429.png)
