### PR TITLE
Feature/annoucement id copy button/179257443

### DIFF
--- a/src/components/Post.tsx
+++ b/src/components/Post.tsx
@@ -63,7 +63,7 @@ const Post = ({ feedItem }: PostProps): JSX.Element => {
           }
         />
       </div>
-      <PostHashDropdown hash={feedItem.hash} />
+      <PostHashDropdown hash={feedItem.hash} fromId={feedItem.fromId} />
       <div className="Post__caption">{noteContent.content}</div>
       {attachments && (
         <PostMedia attachment={attachments as ActivityContentImage[]} />

--- a/src/components/PostHashDropdown.tsx
+++ b/src/components/PostHashDropdown.tsx
@@ -5,15 +5,20 @@ import { HexString } from "../utilities/types";
 
 interface PostHashDropdownProps {
   hash: HexString;
+  fromId: HexString;
   isReply?: boolean;
 }
 
 const PostHashDropdown = ({
   hash,
+  fromId,
   isReply,
 }: PostHashDropdownProps): JSX.Element => {
   const [isCopied, setIsCopied] = useState<boolean>(false);
   const [isVisible, setIsVisible] = useState<boolean>(false);
+
+  const announcementURI = "dsnp://" + fromId + "/" + hash;
+
   const menu = (
     <Menu onClick={() => setIsVisible(true)}>
       <Menu.Item
@@ -32,9 +37,9 @@ const PostHashDropdown = ({
         ) : (
           <div
             className="PostHashDropdown__menuHash"
-            onClick={() => navigator.clipboard.writeText(hash)}
+            onClick={() => navigator.clipboard.writeText(announcementURI)}
           >
-            Hash: {hash}
+            DSNP Announcement URI: {announcementURI}
           </div>
         )}
       </Menu.Item>

--- a/src/components/PostHashDropdown.tsx
+++ b/src/components/PostHashDropdown.tsx
@@ -1,11 +1,16 @@
 import React, { useState } from "react";
 import { Menu, Dropdown } from "antd";
 import { CheckCircleOutlined, EllipsisOutlined } from "@ant-design/icons";
+import {
+  buildDSNPAnnouncementURI,
+  DSNPUserId,
+  DSNPAnnouncementURI,
+} from "@dsnp/sdk/core/identifiers";
 import { HexString } from "../utilities/types";
 
 interface PostHashDropdownProps {
   hash: HexString;
-  fromId: HexString;
+  fromId: DSNPUserId;
   isReply?: boolean;
 }
 
@@ -17,7 +22,10 @@ const PostHashDropdown = ({
   const [isCopied, setIsCopied] = useState<boolean>(false);
   const [isVisible, setIsVisible] = useState<boolean>(false);
 
-  const announcementURI = "dsnp://" + fromId + "/" + hash;
+  const announcementURI: DSNPAnnouncementURI = buildDSNPAnnouncementURI(
+    fromId,
+    hash
+  );
 
   const menu = (
     <Menu onClick={() => setIsVisible(true)}>

--- a/src/components/Reply.tsx
+++ b/src/components/Reply.tsx
@@ -22,7 +22,11 @@ const Reply = ({ reply }: ReplyProps): JSX.Element => {
 
   return (
     <div className="Reply__block">
-      <PostHashDropdown hash={reply.hash} isReply={true} />
+      <PostHashDropdown
+        hash={reply.hash}
+        fromId={reply.fromId}
+        isReply={true}
+      />
       <UserAvatar
         icon={fromProfile?.icon?.[0]?.href}
         profileAddress={reply.fromId}

--- a/src/components/test/Feed.test.tsx
+++ b/src/components/test/Feed.test.tsx
@@ -5,15 +5,16 @@ import { getPrefabFeed } from "../../test/testFeeds";
 import { componentWithStore, createMockStore } from "../../test/testhelpers";
 import { getPreFabSocialGraph } from "../../test/testGraphs";
 import { getPrefabProfile } from "../../test/testProfiles";
+import { FeedItem } from "../../utilities/types";
 
 const userId = getPrefabProfile(0).fromId;
-const feedItems = getPrefabFeed();
+const feedItems: FeedItem[] = getPrefabFeed();
 const graphs = getPreFabSocialGraph();
 const initialState = {
   user: { id: userId },
   feed: {
     feedItems: feedItems,
-    isPostLoading: { loading: false, myIdentifier: undefined },
+    isPostLoading: { loading: false, currentUserId: undefined },
     isReplyLoading: { loading: false, parent: undefined },
   },
   graphs: graphs,
@@ -37,7 +38,7 @@ describe("Feed", () => {
       user: {},
       feed: {
         feedItems,
-        isPostLoading: { loading: false, myIdentifier: undefined },
+        isPostLoading: { loading: false, currentUserId: undefined },
         isReplyLoading: { loading: false, parent: undefined },
       },
       graphs: { graphs },

--- a/src/test/testFeeds.ts
+++ b/src/test/testFeeds.ts
@@ -54,7 +54,7 @@ export const generateFeedItem = (
     content: content,
     replies: replies || [],
     blockNumber: 50,
-    hash: keccak_256("this is a hash of the feed item"),
+    hash: "0x" + keccak_256("this is a hash of the feed item"),
     rawContent: "", // This can be simulated, but it's annoying to do so.
   };
 };


### PR DESCRIPTION
Purpose
---------------
copy announcement URI instead of just the hash

Solution
---------------
create announcement URI based off of the spec: [https://spec.dsnp.org/Identifiers#dsnp-announcement-uri](url)

Change summary
---------------
* bring in fromId to PostHashDropdown
* create proper announcementURI

Steps to Verify
----------------
1. Check that value copied is correct
