### PR TITLE
sign all announcements

### DIFF
--- a/src/services/dsnp.ts
+++ b/src/services/dsnp.ts
@@ -223,10 +223,10 @@ export const buildAndSignPostAnnouncement = async (
   fromId: DSNPUserId,
   url: string,
   hash: string
-): Promise<SignedBroadcastAnnouncement> => ({
-  ...core.announcements.createBroadcast(fromId, url, hash),
-  signature: "0x00000000", // TODO: call out to wallet to get this signed
-});
+): Promise<SignedBroadcastAnnouncement> =>
+  core.announcements.sign(
+    core.announcements.createBroadcast(fromId, url, hash)
+  );
 
 /**
  * Creates a signed reply announcement.
@@ -243,10 +243,10 @@ export const buildAndSignReplyAnnouncement = async (
   inReplyTo: HexString,
   url: string,
   hash: string
-): Promise<SignedReplyAnnouncement> => ({
-  ...core.announcements.createReply(fromId, url, hash, inReplyTo),
-  signature: "0x00000000", // TODO: call out to wallet to get this signed
-});
+): Promise<SignedReplyAnnouncement> =>
+  core.announcements.sign(
+    core.announcements.createReply(fromId, url, hash, inReplyTo)
+  );
 
 /**
  * Creates a signed profile announcement.
@@ -261,7 +261,5 @@ export const buildAndSignProfile = async (
   fromId: DSNPUserId,
   url: string,
   hash: string
-): Promise<SignedProfileAnnouncement> => ({
-  ...core.announcements.createProfile(fromId, url, hash),
-  signature: "0x00000000", // TODO: call out to wallet to get this signed
-});
+): Promise<SignedProfileAnnouncement> =>
+  core.announcements.sign(core.announcements.createProfile(fromId, url, hash));


### PR DESCRIPTION
Purpose
---------------
Announcements must be properly signed in order to be accepted by compliant DSNP clients. This PR adds that functionality to the example client. Note that this now requires two confirmations from the wallet for every DSNP change made: one for the announcement and another to sign the batch it goes into.


Solution
---------------
Add signing to all create and sign content methods.

Steps to Verify
----------------
1. Start the app and sign in.
2. Create a post.
3. Note that the app requires you to sign the message with the wallet before asking you to sign the transaction.
4. Reply to a post.
5. Note that the app requires you to sign the message with the wallet before asking you to sign the transaction.
6. Change your name in the profile.
7. Note that the app requires you to sign the message with the wallet before asking you to sign the transaction.
