### PR TITLE
add utility to build react upload host url

### DIFF
--- a/src/services/Storage.ts
+++ b/src/services/Storage.ts
@@ -9,6 +9,7 @@ import { isFunction, isUint8Array } from "./utilities";
 import { ActivityContentNote } from "@dsnp/sdk/core/activityContent";
 import { noteToActivityContentNote } from "../utilities/activityContent";
 import { DSNPUserId } from "@dsnp/sdk/dist/types/core/identifiers";
+import { buildBaseUploadHostUrl } from "../utilities/buildBaseUploadHostUrl";
 
 export const createNote = async (
   note: string,
@@ -30,7 +31,7 @@ export const createNote = async (
 export class Store implements StoreInterface {
   put(targetPath: string, _content: Content): Promise<URL> {
     return Promise.resolve(
-      new URL(`${process.env.REACT_APP_UPLOAD_HOST}/${targetPath}`)
+      new URL(`${buildBaseUploadHostUrl(true)}/${targetPath}`)
     );
   }
 
@@ -40,7 +41,7 @@ export class Store implements StoreInterface {
   ): Promise<URL> {
     const ws = new ServerWriteStream(targetPath);
     await doWriteToStream(ws);
-    return new URL(`${process.env.REACT_APP_UPLOAD_HOST}/${targetPath}`);
+    return new URL(`${buildBaseUploadHostUrl(true)}/${targetPath}`);
   }
 }
 
@@ -99,9 +100,9 @@ class ServerWriteStream implements WriteStream {
     }
 
     fetch(
-      `${
-        process.env.REACT_APP_UPLOAD_HOST
-      }/upload?filename=${encodeURIComponent(this.targetPath)}`,
+      `${buildBaseUploadHostUrl(false)}/upload?filename=${encodeURIComponent(
+        this.targetPath
+      )}`,
       {
         method: "POST",
         mode: "cors",

--- a/src/services/sdk.ts
+++ b/src/services/sdk.ts
@@ -9,6 +9,7 @@ import { addFeedItem, clearFeedItems } from "../redux/slices/feedSlice";
 import { upsertProfile } from "../redux/slices/profileSlice";
 import { AnyAction, ThunkDispatch } from "@reduxjs/toolkit";
 import { Store } from "./Storage";
+import { buildBaseUploadHostUrl } from "../utilities/buildBaseUploadHostUrl";
 import {
   ActivityContentNote,
   ActivityContentProfile,
@@ -355,7 +356,7 @@ const storeActivityContent = async (
 ): Promise<string> => {
   const hash = keccak256(core.activityContent.serialize(content));
   await fetch(
-    `${process.env.REACT_APP_UPLOAD_HOST}/upload?filename=${encodeURIComponent(
+    `${buildBaseUploadHostUrl(false)}/upload?filename=${encodeURIComponent(
       hash + ".json"
     )}`,
     {
@@ -373,7 +374,7 @@ const buildAndSignPostAnnouncement = async (
 ): Promise<SignedBroadcastAnnouncement> => ({
   ...core.announcements.createBroadcast(
     post.fromId,
-    `${process.env.REACT_APP_UPLOAD_HOST}/${hash}.json`,
+    `${buildBaseUploadHostUrl(true)}/${hash}.json`,
     hash
   ),
   signature: "0x00000000", // TODO: call out to wallet to get this signed
@@ -386,7 +387,7 @@ const buildAndSignReplyAnnouncement = async (
 ): Promise<SignedReplyAnnouncement> => ({
   ...core.announcements.createReply(
     replyFromId,
-    `${process.env.REACT_APP_UPLOAD_HOST}/${hash}.json`,
+    `${buildBaseUploadHostUrl(true)}/${hash}.json`,
     hash,
     replyInReplyTo
   ),
@@ -399,7 +400,7 @@ const buildAndSignProfile = async (
 ): Promise<SignedProfileAnnouncement> => ({
   ...core.announcements.createProfile(
     fromId,
-    `${process.env.REACT_APP_UPLOAD_HOST}/${hash}.json`,
+    `${buildBaseUploadHostUrl(true)}/${hash}.json`,
     hash
   ),
   signature: "0x00000000", // TODO: call out to wallet to get this signed

--- a/src/utilities/buildBaseUploadHostUrl.test.ts
+++ b/src/utilities/buildBaseUploadHostUrl.test.ts
@@ -1,0 +1,40 @@
+import { buildBaseUploadHostUrl } from "./buildBaseUploadHostUrl";
+
+describe("buildBaseUploadHostUrl", () => {
+  let windowSpy: jest.SpyInstance<Window>;
+  const OLD_ENV = process.env;
+
+  beforeEach(() => {
+    jest.resetModules(); // Most important - it clears the cache
+    process.env = { ...OLD_ENV };
+  });
+
+  afterEach(() => {
+    windowSpy.mockRestore();
+  });
+
+  afterAll(() => {
+    process.env = OLD_ENV; // Restore old environment
+  });
+  describe("when needing a qualified url", () => {
+    const originalWindow = { ...window };
+    windowSpy = jest.spyOn(window, "window", "get");
+    windowSpy.mockImplementation((): any => ({
+      ...originalWindow,
+      location: {
+        ...originalWindow.location,
+        host: "http://example.com",
+      },
+    }));
+
+    process.env.REACT_APP_UPLOAD_HOST = "/test";
+
+    it("returns a qualified url for REACT_APP_UPLOAD_HOST", () => {
+      expect(buildBaseUploadHostUrl(true)).toEqual("http://example.com//test");
+    });
+
+    it("does not return a qualified url for REACT_APP_UPLOAD_HOST", () => {
+      expect(buildBaseUploadHostUrl(false)).toEqual("/test");
+    });
+  });
+});

--- a/src/utilities/buildBaseUploadHostUrl.ts
+++ b/src/utilities/buildBaseUploadHostUrl.ts
@@ -1,0 +1,5 @@
+export const buildBaseUploadHostUrl = (qualifiedUrl: boolean): string => {
+  return qualifiedUrl
+    ? `${window.location.host}/${process.env.REACT_APP_UPLOAD_HOST}`
+    : `${process.env.REACT_APP_UPLOAD_HOST}`;
+};


### PR DESCRIPTION
Purpose
---------------
We needed a small function to differentiate when we need a fully qualified url or just the information for the 
`REACT_APP_UPLOAD_HOST`. 

This is because we are serving the react app statically from the static server in our Dockerfile, and so the `REACT_APP_UPLOAD_HOST` is the same as the base url for the static sever. In certain places in the code we use `fetch` to resolve a url - which is able to resolve an empty `REACT_APP_UPLOAD_HOST` to the base url of the server. However in other places we are just building a URL and so need to find the fully qualified URL. 


Solution
----------------
Write a small utility function that will return a qualified url when needed. 


Change summary
---------------
* Add a small utility function that will return a qualified Url when needed. 
* Add a spec

