### PR TITLE
upgrade to sdk 3

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -2,6 +2,9 @@
   "globals": {
     "JSX": true
   },
+  "env": {
+    "es2020": true
+  },
   "plugins": ["jest", "prettier", "react-hooks"],
   "parser": "@typescript-eslint/parser",
   "parserOptions": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@dsnp/contracts": "1.0.1",
         "@dsnp/parquetjs": "^1.1.0",
-        "@dsnp/sdk": "^3.0.1",
+        "@dsnp/sdk": "^3.0.2",
         "@reduxjs/toolkit": "^1.5.1",
         "@toruslabs/torus-embed": "1.9.2",
         "antd": "^4.13.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@dsnp/contracts": "1.0.1",
         "@dsnp/parquetjs": "^1.1.0",
-        "@dsnp/sdk": "^0.0.0-440437",
+        "@dsnp/sdk": "^3.0.1",
         "@reduxjs/toolkit": "^1.5.1",
         "@toruslabs/torus-embed": "1.9.2",
         "antd": "^4.13.1",
@@ -2019,29 +2019,17 @@
       "integrity": "sha512-CMJe7tWWq6X4Vjy5bio991jcwo9KoWnKKws+fpCwPNBDdPQIUw3hSqUaTtulWpUn3jsrKNUsyKSJRH19vMAZJQ=="
     },
     "node_modules/@dsnp/parquetjs": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@dsnp/parquetjs/-/parquetjs-1.1.1.tgz",
-      "integrity": "sha512-CwjJ9q7jiQgkbiIB3HNiMYIF03CP819F3IRYgQpRklR5YUwWrw+Wz4oo5yTtcS7EaMov0IoRzv54eBl88XDZLQ==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@dsnp/parquetjs/-/parquetjs-1.1.2.tgz",
+      "integrity": "sha512-19OxnEit/AJ5ObOTj3i5sFmyTMwifrLFTsXnBwrPf/BT9Ev1zILT2LD87PGVpFWDpn8frb/kSwADgqPT4sTH5w==",
       "dependencies": {
-        "@types/bson": "^4.0.3",
-        "@types/long": "^4.0.1",
-        "@types/node": "^14.14.35",
-        "@types/thrift": "^0.10.10",
-        "assert": "^2.0.0",
         "browserify-zlib": "^0.2.0",
         "bson": "4.4.0",
         "cross-fetch": "^3.1.4",
-        "esbuild": "^0.12.11",
-        "events": "^3.3.0",
         "int53": "^0.2.4",
-        "lodash": "^4.17.21",
         "long": "^4.0.0",
-        "object-stream": "0.0.1",
-        "path-browserify": "^1.0.1",
-        "readable-stream": "^3.6.0",
         "snappyjs": "^0.6.0",
         "thrift": "0.14.1",
-        "util": "^0.12.4",
         "varint": "^5.0.0",
         "wasm-brotli": "^2.0.2",
         "xxhash-wasm": "^0.4.1"
@@ -2051,17 +2039,17 @@
       }
     },
     "node_modules/@dsnp/sdk": {
-      "version": "0.0.0-440437",
-      "resolved": "https://registry.npmjs.org/@dsnp/sdk/-/sdk-0.0.0-440437.tgz",
-      "integrity": "sha512-hawiteAAA/ZraCRJCS1CGHrz2LomB0omVbsECAYgzr1/eXvNQwmDKhedsyhP7na/hBh8WpJmSmFlpaS6uEzedQ==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@dsnp/sdk/-/sdk-3.0.2.tgz",
+      "integrity": "sha512-JK6r46Q3piTjp2OBFShx8HI3qmJkQmfumMDvprpMhwi/YQBgqPstQr0QgSjrIksBXfC+nRwSO1iTIsATm7VRAQ==",
       "dependencies": {
         "@dsnp/contracts": "1.0.1",
-        "@dsnp/parquetjs": "^1.1.1",
+        "@dsnp/parquetjs": "^1.1.2",
         "@dsnp/test-generators": "^0.1.0",
         "@ethersproject/abi": "^5.4.0",
         "ethers": "^5.4.4",
         "js-sha3": "^0.8.0",
-        "ws": "^8.0.0"
+        "ws": "^8.1.0"
       },
       "engines": {
         "node": ">=14.15.5"
@@ -2073,9 +2061,9 @@
       "integrity": "sha512-QskTEzek9Yf9SEv7ZxKWdwFoOcULOM+d0GhRyC9KxyzA/SdxsL1l9AdHJfI8KEVnP7WBJZmc/bEaAynSIVHHVQ=="
     },
     "node_modules/@dsnp/sdk/node_modules/ws": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.0.0.tgz",
-      "integrity": "sha512-6AcSIXpBlS0QvCVKk+3cWnWElLsA6SzC0lkQ43ciEglgXJXiCWK3/CGFEJ+Ybgp006CMibamAsqOlxE9s4AvYA==",
+      "version": "8.2.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.2.1.tgz",
+      "integrity": "sha512-XkgWpJU3sHU7gX8f13NqTn6KQ85bd1WU7noBHTT8fSohx7OS1TPY8k+cyRPCzFkia7C4mM229yeHr1qK9sM4JQ==",
       "engines": {
         "node": ">=10.0.0"
       },
@@ -4246,14 +4234,6 @@
         "@types/node": "*"
       }
     },
-    "node_modules/@types/bson": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/@types/bson/-/bson-4.0.5.tgz",
-      "integrity": "sha512-vVLwMUqhYJSQ/WKcE60eFqcyuWse5fGH+NMAXHuKrUAPoryq3ATxk5o4bgYNtg5aOM4APVg7Hnb3ASqUYG0PKg==",
-      "dependencies": {
-        "@types/node": "*"
-      }
-    },
     "node_modules/@types/cheerio": {
       "version": "0.22.30",
       "resolved": "https://registry.npmjs.org/@types/cheerio/-/cheerio-0.22.30.tgz",
@@ -4412,11 +4392,6 @@
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.8.tgz",
       "integrity": "sha512-YSBPTLTVm2e2OoQIDYx8HaeWJ5tTToLH67kXR7zYNGupXMEHa2++G8k+DczX2cFVgalypqtyZIcU19AFcmOpmg=="
     },
-    "node_modules/@types/long": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/@types/long/-/long-4.0.1.tgz",
-      "integrity": "sha512-5tXH6Bx/kNGd3MgffdmP4dy2Z+G4eaXw0SE81Tq3BNadtnMR5/ySMzX4SLEzHJzSmPNn4HIdpQsBvXMUykr58w=="
-    },
     "node_modules/@types/mdast": {
       "version": "3.0.7",
       "resolved": "https://registry.npmjs.org/@types/mdast/-/mdast-3.0.7.tgz",
@@ -4442,14 +4417,6 @@
       "version": "14.17.6",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-14.17.6.tgz",
       "integrity": "sha512-iBxsxU7eswQDGhlr3AiamBxOssaYxbM+NKXVil8jg9yFXvrfEFbDumLD/2dMTB+zYyg7w+Xjt8yuxfdbUHAtcQ=="
-    },
-    "node_modules/@types/node-int64": {
-      "version": "0.4.29",
-      "resolved": "https://registry.npmjs.org/@types/node-int64/-/node-int64-0.4.29.tgz",
-      "integrity": "sha512-rHXvenLTj/CcsmNAebaBOhxQ2MqEGl3yXZZcZ21XYR+gzGTTcpOy2N4IxpvTCz48loyQNatHvfn6GhIbbZ1R3Q==",
-      "dependencies": {
-        "@types/node": "*"
-      }
     },
     "node_modules/@types/normalize-package-data": {
       "version": "2.4.1",
@@ -4482,7 +4449,8 @@
     "node_modules/@types/q": {
       "version": "1.5.5",
       "resolved": "https://registry.npmjs.org/@types/q/-/q-1.5.5.tgz",
-      "integrity": "sha512-L28j2FcJfSZOnL1WBjDYp2vUHCeIFlyYI/53EwD/rKUBQ7MtUUfbQWiyKJGpcnv4/WgrhWsFKrcPstcAt/J0tQ=="
+      "integrity": "sha512-L28j2FcJfSZOnL1WBjDYp2vUHCeIFlyYI/53EwD/rKUBQ7MtUUfbQWiyKJGpcnv4/WgrhWsFKrcPstcAt/J0tQ==",
+      "dev": true
     },
     "node_modules/@types/react": {
       "version": "17.0.3",
@@ -4591,16 +4559,6 @@
       "resolved": "https://registry.npmjs.org/@types/tapable/-/tapable-1.0.8.tgz",
       "integrity": "sha512-ipixuVrh2OdNmauvtT51o3d8z12p6LtFW9in7U79der/kwejjdNchQC5UMn5u/KxNoM7VHHOs/l8KS8uHxhODQ==",
       "dev": true
-    },
-    "node_modules/@types/thrift": {
-      "version": "0.10.11",
-      "resolved": "https://registry.npmjs.org/@types/thrift/-/thrift-0.10.11.tgz",
-      "integrity": "sha512-skAJTzEcz0RSKX/oooCz4nrLW+lgAq3Wy0imNRqwVpw2ODYKaQHg6iRA5Ig5tzvbFAWPUb9BcQWCf0Ul+IYyCw==",
-      "dependencies": {
-        "@types/node": "*",
-        "@types/node-int64": "*",
-        "@types/q": "*"
-      }
     },
     "node_modules/@types/uglify-js": {
       "version": "3.13.1",
@@ -5743,17 +5701,6 @@
         "inherits": "^2.0.1",
         "minimalistic-assert": "^1.0.0",
         "safer-buffer": "^2.1.0"
-      }
-    },
-    "node_modules/assert": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/assert/-/assert-2.0.0.tgz",
-      "integrity": "sha512-se5Cd+js9dXJnu6Ag2JFc00t+HmHOen+8Q+L7O9zI0PqQXr20uk2J0XQqMxZEeo5U50o8Nvmmx7dZrl+Ufr35A==",
-      "dependencies": {
-        "es6-object-assign": "^1.1.0",
-        "is-nan": "^1.2.1",
-        "object-is": "^1.0.1",
-        "util": "^0.12.0"
       }
     },
     "node_modules/assert-plus": {
@@ -10245,11 +10192,6 @@
         "es6-symbol": "^3.1.1"
       }
     },
-    "node_modules/es6-object-assign": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/es6-object-assign/-/es6-object-assign-1.1.0.tgz",
-      "integrity": "sha1-wsNYJlYkfDnqEHyx5mUrb58kUjw="
-    },
     "node_modules/es6-promise": {
       "version": "4.2.8",
       "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.8.tgz",
@@ -10262,15 +10204,6 @@
       "dependencies": {
         "d": "^1.0.1",
         "ext": "^1.1.2"
-      }
-    },
-    "node_modules/esbuild": {
-      "version": "0.12.17",
-      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.12.17.tgz",
-      "integrity": "sha512-GshKJyVYUnlSXIZj/NheC2O0Kblh42CS7P1wJyTbbIHevTG4jYMS9NNw8EOd8dDWD0dzydYHS01MpZoUcQXB4g==",
-      "hasInstallScript": true,
-      "bin": {
-        "esbuild": "bin/esbuild"
       }
     },
     "node_modules/escalade": {
@@ -14286,21 +14219,6 @@
       "resolved": "https://registry.npmjs.org/is-module/-/is-module-1.0.0.tgz",
       "integrity": "sha1-Mlj7afeMFNW4FdZkM2tM/7ZEFZE=",
       "dev": true
-    },
-    "node_modules/is-nan": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/is-nan/-/is-nan-1.3.2.tgz",
-      "integrity": "sha512-E+zBKpQ2t6MEo1VsonYmluk9NxGrbzpeeLC2xIViuO2EjU2xsXsBPwTr3Ykv9l08UYEVEdWeRZNouaZqF6RN0w==",
-      "dependencies": {
-        "call-bind": "^1.0.0",
-        "define-properties": "^1.1.3"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
     },
     "node_modules/is-negative-zero": {
       "version": "2.0.1",
@@ -21129,6 +21047,7 @@
       "version": "1.1.5",
       "resolved": "https://registry.npmjs.org/object-is/-/object-is-1.1.5.tgz",
       "integrity": "sha512-3cyDsyHgtmi7I7DfSSI2LDp6SK2lwvtbg0p0R1e0RvTqF5ceGx+K2dfSjm1bKDMVCFEDAQvy+o8c6a7VujOddw==",
+      "dev": true,
       "dependencies": {
         "call-bind": "^1.0.2",
         "define-properties": "^1.1.3"
@@ -21146,14 +21065,6 @@
       "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
       "engines": {
         "node": ">= 0.4"
-      }
-    },
-    "node_modules/object-stream": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/object-stream/-/object-stream-0.0.1.tgz",
-      "integrity": "sha1-OgOibpT9ESyav/60ZR4HpeI8+EA=",
-      "engines": {
-        "node": ">=0.10"
       }
     },
     "node_modules/object-visit": {
@@ -21684,11 +21595,6 @@
       "engines": {
         "node": ">=0.10.0"
       }
-    },
-    "node_modules/path-browserify": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-1.0.1.tgz",
-      "integrity": "sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g=="
     },
     "node_modules/path-dirname": {
       "version": "1.0.2",
@@ -36858,46 +36764,34 @@
       "integrity": "sha512-CMJe7tWWq6X4Vjy5bio991jcwo9KoWnKKws+fpCwPNBDdPQIUw3hSqUaTtulWpUn3jsrKNUsyKSJRH19vMAZJQ=="
     },
     "@dsnp/parquetjs": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@dsnp/parquetjs/-/parquetjs-1.1.1.tgz",
-      "integrity": "sha512-CwjJ9q7jiQgkbiIB3HNiMYIF03CP819F3IRYgQpRklR5YUwWrw+Wz4oo5yTtcS7EaMov0IoRzv54eBl88XDZLQ==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@dsnp/parquetjs/-/parquetjs-1.1.2.tgz",
+      "integrity": "sha512-19OxnEit/AJ5ObOTj3i5sFmyTMwifrLFTsXnBwrPf/BT9Ev1zILT2LD87PGVpFWDpn8frb/kSwADgqPT4sTH5w==",
       "requires": {
-        "@types/bson": "^4.0.3",
-        "@types/long": "^4.0.1",
-        "@types/node": "^14.14.35",
-        "@types/thrift": "^0.10.10",
-        "assert": "^2.0.0",
         "browserify-zlib": "^0.2.0",
         "bson": "4.4.0",
         "cross-fetch": "^3.1.4",
-        "esbuild": "^0.12.11",
-        "events": "^3.3.0",
         "int53": "^0.2.4",
-        "lodash": "^4.17.21",
         "long": "^4.0.0",
-        "object-stream": "0.0.1",
-        "path-browserify": "^1.0.1",
-        "readable-stream": "^3.6.0",
         "snappyjs": "^0.6.0",
         "thrift": "0.14.1",
-        "util": "^0.12.4",
         "varint": "^5.0.0",
         "wasm-brotli": "^2.0.2",
         "xxhash-wasm": "^0.4.1"
       }
     },
     "@dsnp/sdk": {
-      "version": "0.0.0-440437",
-      "resolved": "https://registry.npmjs.org/@dsnp/sdk/-/sdk-0.0.0-440437.tgz",
-      "integrity": "sha512-hawiteAAA/ZraCRJCS1CGHrz2LomB0omVbsECAYgzr1/eXvNQwmDKhedsyhP7na/hBh8WpJmSmFlpaS6uEzedQ==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@dsnp/sdk/-/sdk-3.0.2.tgz",
+      "integrity": "sha512-JK6r46Q3piTjp2OBFShx8HI3qmJkQmfumMDvprpMhwi/YQBgqPstQr0QgSjrIksBXfC+nRwSO1iTIsATm7VRAQ==",
       "requires": {
         "@dsnp/contracts": "1.0.1",
-        "@dsnp/parquetjs": "^1.1.1",
+        "@dsnp/parquetjs": "^1.1.2",
         "@dsnp/test-generators": "^0.1.0",
         "@ethersproject/abi": "^5.4.0",
         "ethers": "^5.4.4",
         "js-sha3": "^0.8.0",
-        "ws": "^8.0.0"
+        "ws": "^8.1.0"
       },
       "dependencies": {
         "@dsnp/test-generators": {
@@ -36906,9 +36800,9 @@
           "integrity": "sha512-QskTEzek9Yf9SEv7ZxKWdwFoOcULOM+d0GhRyC9KxyzA/SdxsL1l9AdHJfI8KEVnP7WBJZmc/bEaAynSIVHHVQ=="
         },
         "ws": {
-          "version": "8.0.0",
-          "resolved": "https://registry.npmjs.org/ws/-/ws-8.0.0.tgz",
-          "integrity": "sha512-6AcSIXpBlS0QvCVKk+3cWnWElLsA6SzC0lkQ43ciEglgXJXiCWK3/CGFEJ+Ybgp006CMibamAsqOlxE9s4AvYA==",
+          "version": "8.2.1",
+          "resolved": "https://registry.npmjs.org/ws/-/ws-8.2.1.tgz",
+          "integrity": "sha512-XkgWpJU3sHU7gX8f13NqTn6KQ85bd1WU7noBHTT8fSohx7OS1TPY8k+cyRPCzFkia7C4mM229yeHr1qK9sM4JQ==",
           "requires": {}
         }
       }
@@ -38362,14 +38256,6 @@
         "@types/node": "*"
       }
     },
-    "@types/bson": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/@types/bson/-/bson-4.0.5.tgz",
-      "integrity": "sha512-vVLwMUqhYJSQ/WKcE60eFqcyuWse5fGH+NMAXHuKrUAPoryq3ATxk5o4bgYNtg5aOM4APVg7Hnb3ASqUYG0PKg==",
-      "requires": {
-        "@types/node": "*"
-      }
-    },
     "@types/cheerio": {
       "version": "0.22.30",
       "resolved": "https://registry.npmjs.org/@types/cheerio/-/cheerio-0.22.30.tgz",
@@ -38518,11 +38404,6 @@
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.8.tgz",
       "integrity": "sha512-YSBPTLTVm2e2OoQIDYx8HaeWJ5tTToLH67kXR7zYNGupXMEHa2++G8k+DczX2cFVgalypqtyZIcU19AFcmOpmg=="
     },
-    "@types/long": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/@types/long/-/long-4.0.1.tgz",
-      "integrity": "sha512-5tXH6Bx/kNGd3MgffdmP4dy2Z+G4eaXw0SE81Tq3BNadtnMR5/ySMzX4SLEzHJzSmPNn4HIdpQsBvXMUykr58w=="
-    },
     "@types/mdast": {
       "version": "3.0.7",
       "resolved": "https://registry.npmjs.org/@types/mdast/-/mdast-3.0.7.tgz",
@@ -38548,14 +38429,6 @@
       "version": "14.17.6",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-14.17.6.tgz",
       "integrity": "sha512-iBxsxU7eswQDGhlr3AiamBxOssaYxbM+NKXVil8jg9yFXvrfEFbDumLD/2dMTB+zYyg7w+Xjt8yuxfdbUHAtcQ=="
-    },
-    "@types/node-int64": {
-      "version": "0.4.29",
-      "resolved": "https://registry.npmjs.org/@types/node-int64/-/node-int64-0.4.29.tgz",
-      "integrity": "sha512-rHXvenLTj/CcsmNAebaBOhxQ2MqEGl3yXZZcZ21XYR+gzGTTcpOy2N4IxpvTCz48loyQNatHvfn6GhIbbZ1R3Q==",
-      "requires": {
-        "@types/node": "*"
-      }
     },
     "@types/normalize-package-data": {
       "version": "2.4.1",
@@ -38588,7 +38461,8 @@
     "@types/q": {
       "version": "1.5.5",
       "resolved": "https://registry.npmjs.org/@types/q/-/q-1.5.5.tgz",
-      "integrity": "sha512-L28j2FcJfSZOnL1WBjDYp2vUHCeIFlyYI/53EwD/rKUBQ7MtUUfbQWiyKJGpcnv4/WgrhWsFKrcPstcAt/J0tQ=="
+      "integrity": "sha512-L28j2FcJfSZOnL1WBjDYp2vUHCeIFlyYI/53EwD/rKUBQ7MtUUfbQWiyKJGpcnv4/WgrhWsFKrcPstcAt/J0tQ==",
+      "dev": true
     },
     "@types/react": {
       "version": "17.0.3",
@@ -38697,16 +38571,6 @@
       "resolved": "https://registry.npmjs.org/@types/tapable/-/tapable-1.0.8.tgz",
       "integrity": "sha512-ipixuVrh2OdNmauvtT51o3d8z12p6LtFW9in7U79der/kwejjdNchQC5UMn5u/KxNoM7VHHOs/l8KS8uHxhODQ==",
       "dev": true
-    },
-    "@types/thrift": {
-      "version": "0.10.11",
-      "resolved": "https://registry.npmjs.org/@types/thrift/-/thrift-0.10.11.tgz",
-      "integrity": "sha512-skAJTzEcz0RSKX/oooCz4nrLW+lgAq3Wy0imNRqwVpw2ODYKaQHg6iRA5Ig5tzvbFAWPUb9BcQWCf0Ul+IYyCw==",
-      "requires": {
-        "@types/node": "*",
-        "@types/node-int64": "*",
-        "@types/q": "*"
-      }
     },
     "@types/uglify-js": {
       "version": "3.13.1",
@@ -39600,17 +39464,6 @@
         "inherits": "^2.0.1",
         "minimalistic-assert": "^1.0.0",
         "safer-buffer": "^2.1.0"
-      }
-    },
-    "assert": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/assert/-/assert-2.0.0.tgz",
-      "integrity": "sha512-se5Cd+js9dXJnu6Ag2JFc00t+HmHOen+8Q+L7O9zI0PqQXr20uk2J0XQqMxZEeo5U50o8Nvmmx7dZrl+Ufr35A==",
-      "requires": {
-        "es6-object-assign": "^1.1.0",
-        "is-nan": "^1.2.1",
-        "object-is": "^1.0.1",
-        "util": "^0.12.0"
       }
     },
     "assert-plus": {
@@ -43211,11 +43064,6 @@
         "es6-symbol": "^3.1.1"
       }
     },
-    "es6-object-assign": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/es6-object-assign/-/es6-object-assign-1.1.0.tgz",
-      "integrity": "sha1-wsNYJlYkfDnqEHyx5mUrb58kUjw="
-    },
     "es6-promise": {
       "version": "4.2.8",
       "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.8.tgz",
@@ -43229,11 +43077,6 @@
         "d": "^1.0.1",
         "ext": "^1.1.2"
       }
-    },
-    "esbuild": {
-      "version": "0.12.17",
-      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.12.17.tgz",
-      "integrity": "sha512-GshKJyVYUnlSXIZj/NheC2O0Kblh42CS7P1wJyTbbIHevTG4jYMS9NNw8EOd8dDWD0dzydYHS01MpZoUcQXB4g=="
     },
     "escalade": {
       "version": "3.1.1",
@@ -46338,15 +46181,6 @@
       "resolved": "https://registry.npmjs.org/is-module/-/is-module-1.0.0.tgz",
       "integrity": "sha1-Mlj7afeMFNW4FdZkM2tM/7ZEFZE=",
       "dev": true
-    },
-    "is-nan": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/is-nan/-/is-nan-1.3.2.tgz",
-      "integrity": "sha512-E+zBKpQ2t6MEo1VsonYmluk9NxGrbzpeeLC2xIViuO2EjU2xsXsBPwTr3Ykv9l08UYEVEdWeRZNouaZqF6RN0w==",
-      "requires": {
-        "call-bind": "^1.0.0",
-        "define-properties": "^1.1.3"
-      }
     },
     "is-negative-zero": {
       "version": "2.0.1",
@@ -51723,6 +51557,7 @@
       "version": "1.1.5",
       "resolved": "https://registry.npmjs.org/object-is/-/object-is-1.1.5.tgz",
       "integrity": "sha512-3cyDsyHgtmi7I7DfSSI2LDp6SK2lwvtbg0p0R1e0RvTqF5ceGx+K2dfSjm1bKDMVCFEDAQvy+o8c6a7VujOddw==",
+      "dev": true,
       "requires": {
         "call-bind": "^1.0.2",
         "define-properties": "^1.1.3"
@@ -51732,11 +51567,6 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
       "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA=="
-    },
-    "object-stream": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/object-stream/-/object-stream-0.0.1.tgz",
-      "integrity": "sha1-OgOibpT9ESyav/60ZR4HpeI8+EA="
     },
     "object-visit": {
       "version": "1.0.1",
@@ -52157,11 +51987,6 @@
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/pascalcase/-/pascalcase-0.1.1.tgz",
       "integrity": "sha1-s2PlXoAGym/iF4TS2yK9FdeRfxQ="
-    },
-    "path-browserify": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-1.0.1.tgz",
-      "integrity": "sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g=="
     },
     "path-dirname": {
       "version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "dependencies": {
     "@dsnp/contracts": "1.0.1",
     "@dsnp/parquetjs": "^1.1.0",
-    "@dsnp/sdk": "^0.0.0-440437",
+    "@dsnp/sdk": "^3.0.1",
     "@reduxjs/toolkit": "^1.5.1",
     "@toruslabs/torus-embed": "1.9.2",
     "antd": "^4.13.1",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "dependencies": {
     "@dsnp/contracts": "1.0.1",
     "@dsnp/parquetjs": "^1.1.0",
-    "@dsnp/sdk": "^3.0.1",
+    "@dsnp/sdk": "^3.0.2",
     "@reduxjs/toolkit": "^1.5.1",
     "@toruslabs/torus-embed": "1.9.2",
     "antd": "^4.13.1",

--- a/scripts/populate.mjs
+++ b/scripts/populate.mjs
@@ -443,13 +443,8 @@ setConfig({
   store: new Store(),
 });
 
-const dsnpIdToURI = (dsnpId) =>
-  core.identifiers.convertBigNumberToDSNPUserURI(
-    core.identifiers.convertDSNPUserIdOrURIToBigNumber(dsnpId)
-  );
-
 const storeAnnouncement = async (content, accountId, signer) => {
-  const hash = web3.keccak256(core.activityContent.serialize(content));
+  const hash = web3.keccak256(JSON.stringify(content));
 
   // store note content
   await fetch(
@@ -591,8 +586,8 @@ for await (let account of accounts.values()) {
   // create follow
   const follows = await Promise.all(
     account.follows.map((accountIndex) =>
-      follow(dsnpIdToURI(accounts[accountIndex].id), {
-        currentFromURI: dsnpIdToURI(account.id),
+      follow(core.identifiers.convertToDSNPUserURI(accounts[accountIndex].id), {
+        currentFromURI: core.identifiers.convertToDSNPUserURI(account.id),
       })
     )
   );

--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -7,11 +7,7 @@ import { componentWithStore, createMockStore } from "./test/testhelpers";
 import * as dsnp from "./services/dsnp";
 import * as content from "./services/content";
 import * as hooks from "./redux/hooks";
-<<<<<<< HEAD
-import { UnsubscribeFunction } from "@dsnp/sdk/dist/types/core/contracts/utilities";
-=======
 import { UnsubscribeFunction } from "./services/dsnp";
->>>>>>> 199ad5d... changes to support SDK 3
 
 jest.mock("../src/components/Header", () => () => <div> Header </div>);
 jest.mock("../src/components/Feed", () => () => <div> Feed </div>);

--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -7,7 +7,11 @@ import { componentWithStore, createMockStore } from "./test/testhelpers";
 import * as dsnp from "./services/dsnp";
 import * as content from "./services/content";
 import * as hooks from "./redux/hooks";
+<<<<<<< HEAD
 import { UnsubscribeFunction } from "@dsnp/sdk/dist/types/core/contracts/utilities";
+=======
+import { UnsubscribeFunction } from "./services/dsnp";
+>>>>>>> 199ad5d... changes to support SDK 3
 
 jest.mock("../src/components/Header", () => () => <div> Header </div>);
 jest.mock("../src/components/Feed", () => () => <div> Feed </div>);

--- a/src/components/ConnectionsList.tsx
+++ b/src/components/ConnectionsList.tsx
@@ -2,7 +2,6 @@ import React, { useState } from "react";
 import { Button } from "antd";
 import ConnectionsListProfiles from "./ConnectionsListProfiles";
 import { useAppSelector } from "../redux/hooks";
-import { DSNPUserId } from "@dsnp/sdk/dist/types/core/identifiers";
 
 enum ListStatus {
   CLOSED,
@@ -11,9 +10,7 @@ enum ListStatus {
 }
 
 const ConnectionsList = (): JSX.Element => {
-  const userId: DSNPUserId | undefined = useAppSelector(
-    (state) => state.user.id
-  );
+  const userId: string | undefined = useAppSelector((state) => state.user.id);
   const following = useAppSelector(
     (state) => (userId && state.graphs.following[userId]) || {}
   );

--- a/src/components/ConnectionsListProfiles.tsx
+++ b/src/components/ConnectionsListProfiles.tsx
@@ -4,7 +4,6 @@ import { Button } from "antd";
 import { Profile } from "../utilities/types";
 import { HexString } from "@dsnp/sdk/dist/types/types/Strings";
 import { useAppSelector } from "../redux/hooks";
-import { DSNPUserId } from "@dsnp/sdk/dist/types/core/identifiers";
 import { createProfile } from "@dsnp/sdk/core/activityContent";
 import { AnnouncementType } from "@dsnp/sdk/core/announcements";
 
@@ -16,8 +15,8 @@ enum ListStatus {
 
 interface ConnectionsListProfilesProps {
   listStatus: ListStatus;
-  following: Record<DSNPUserId, boolean>;
-  followers: Record<DSNPUserId, boolean>;
+  following: Record<string, boolean>;
+  followers: Record<string, boolean>;
 }
 
 const ConnectionsListProfiles = ({
@@ -32,7 +31,7 @@ const ConnectionsListProfiles = ({
     (state) => state.profiles?.profiles || {}
   );
 
-  const profileForId = (userId: DSNPUserId): Profile =>
+  const profileForId = (userId: string): Profile =>
     profiles[userId] || {
       ...createProfile({ name: "Anonymous" }),
       contentHash: "",

--- a/src/components/Feed.tsx
+++ b/src/components/Feed.tsx
@@ -19,6 +19,7 @@ const Feed = (): JSX.Element => {
 
   const userId = useAppSelector((state) => state.user.id);
   const displayId = useAppSelector((state) => state.user.displayId);
+
   const profiles: Record<types.HexString, types.Profile> = useAppSelector(
     (state) => state.profiles?.profiles || {}
   );
@@ -38,11 +39,11 @@ const Feed = (): JSX.Element => {
     <div className="Feed__block">
       <div className="Feed__header">
         <nav className="Feed__navigation">
-          {displayId !== userId && (
+          {userId && displayId && displayId !== userId && (
             <>
               <div
                 className="Feed__backArrow"
-                onClick={() => dispatch(setDisplayId(userId as string))}
+                onClick={() => dispatch(setDisplayId(BigInt(userId)))}
               >
                 <ArrowLeftOutlined />
               </div>

--- a/src/components/Login.tsx
+++ b/src/components/Login.tsx
@@ -33,7 +33,7 @@ const Login = ({ isPrimary, loginWalletOptions }: LoginProps): JSX.Element => {
   const currentWalletType = useAppSelector((state) => state.user.walletType);
 
   const setUserID = (fromURI: string) => {
-    const fromId = core.identifiers.convertDSNPUserURIToDSNPUserId(fromURI);
+    const fromId = core.identifiers.convertToDSNPUserId(fromURI);
     dispatch(userUpdateId(fromId));
     session.upsertSessionUserId(fromId);
     setRegistrationVisible(false);
@@ -74,7 +74,7 @@ const Login = ({ isPrimary, loginWalletOptions }: LoginProps): JSX.Element => {
     if (!userId) return;
     session.clearSession();
     if (currentWalletType !== wallet.WalletType.NONE) {
-      wallet.wallet(currentWalletType).logout();
+      wallet.wallet(currentWalletType)?.logout();
     }
     dispatch(userLogout());
   };

--- a/src/components/NewPost.tsx
+++ b/src/components/NewPost.tsx
@@ -8,7 +8,6 @@ import { createNote } from "../services/Storage";
 import { sendPost } from "../services/content";
 import { createProfile } from "@dsnp/sdk/core/activityContent";
 import { FromTitle } from "./FromTitle";
-import { DSNPUserId } from "@dsnp/sdk/dist/types/core/identifiers";
 import { postLoading } from "../redux/slices/feedSlice";
 
 interface NewPostProps {
@@ -23,9 +22,7 @@ const NewPost = ({ onSuccess, onCancel }: NewPostProps): JSX.Element => {
   const [postMessage, setPostMessage] = React.useState<string>("");
   const [isValidPost, setIsValidPost] = React.useState<boolean>(false);
 
-  const userId: DSNPUserId | undefined = useAppSelector(
-    (state) => state.user.id
-  );
+  const userId: string | undefined = useAppSelector((state) => state.user.id);
 
   const profiles: Record<HexString, Profile> = useAppSelector(
     (state) => state.profiles?.profiles || {}
@@ -42,7 +39,7 @@ const NewPost = ({ onSuccess, onCancel }: NewPostProps): JSX.Element => {
   };
 
   const createPost = async () => {
-    if (!profile) return;
+    if (!userId || !profile) return;
     const newPostFeedItem: FeedItem = await createNote(
       postMessage,
       uriList,

--- a/src/components/NewPost.tsx
+++ b/src/components/NewPost.tsx
@@ -39,7 +39,7 @@ const NewPost = ({ onSuccess, onCancel }: NewPostProps): JSX.Element => {
   };
 
   const createPost = async () => {
-    if (!userId || !profile) return;
+    if (!userId) return;
     const newPostFeedItem: FeedItem = await createNote(
       postMessage,
       uriList,

--- a/src/components/PostList.tsx
+++ b/src/components/PostList.tsx
@@ -2,7 +2,6 @@ import React from "react";
 import Post from "./Post";
 import { FeedItem } from "../utilities/types";
 import { useAppSelector } from "../redux/hooks";
-import { DSNPUserId } from "@dsnp/sdk/dist/types/core/identifiers";
 import BlankPost from "./BlankPost";
 
 enum FeedTypes {
@@ -25,10 +24,8 @@ const sortFeed = (feed: FeedItem[]): FeedItem[] => {
 };
 
 const PostList = ({ feedType }: PostListProps): JSX.Element => {
-  const userId: DSNPUserId | undefined = useAppSelector(
-    (state) => state.user.id
-  );
-  const myGraph: Record<DSNPUserId, boolean> = useAppSelector(
+  const userId: string | undefined = useAppSelector((state) => state.user.id);
+  const myGraph: Record<string, boolean> = useAppSelector(
     (state) => (userId ? state.graphs.following[userId] : undefined) || {}
   );
 

--- a/src/components/Profile.tsx
+++ b/src/components/Profile.tsx
@@ -4,16 +4,13 @@ import ConnectionsList from "./ConnectionsList";
 import React, { useEffect, useState } from "react";
 import { useAppSelector } from "../redux/hooks";
 import * as types from "../utilities/types";
-import { DSNPUserId } from "@dsnp/sdk/dist/types/core/identifiers";
 import { saveProfile } from "../services/content";
 import { core } from "@dsnp/sdk";
 
 const Profile = (): JSX.Element => {
-  const userId: DSNPUserId | undefined = useAppSelector(
-    (state) => state.user.id
-  );
+  const userId: string | undefined = useAppSelector((state) => state.user.id);
 
-  const displayId: DSNPUserId | undefined = useAppSelector(
+  const displayId: string | undefined = useAppSelector(
     (state) => state.user.displayId
   );
 
@@ -52,12 +49,12 @@ const Profile = (): JSX.Element => {
 
   const saveEditProfile = async () => {
     setIsEditing(!isEditing);
-    if (displayId === undefined || newName === undefined) return;
+    if (userId === undefined || newName === undefined) return;
     const newProfile = core.activityContent.createProfile({
       name: newName,
       icon: profile?.icon,
     });
-    await saveProfile(displayId, newProfile);
+    await saveProfile(BigInt(userId), newProfile);
   };
 
   const cancelEditProfile = () => {

--- a/src/components/ProfileBlock.tsx
+++ b/src/components/ProfileBlock.tsx
@@ -2,14 +2,11 @@ import React from "react";
 import LoginSetupInstructions from "./LoginSetupInstructions";
 import Profile from "./Profile";
 import { useAppSelector } from "../redux/hooks";
-import { DSNPUserId } from "@dsnp/sdk/dist/types/core/identifiers";
 
 const ProfileBlock = (): JSX.Element => {
-  const userId: DSNPUserId | undefined = useAppSelector(
-    (state) => state.user.id
-  );
+  const userId: string | undefined = useAppSelector((state) => state.user.id);
 
-  const displayId: DSNPUserId | undefined = useAppSelector(
+  const displayId: string | undefined = useAppSelector(
     (state) => state.user.displayId
   );
 

--- a/src/components/RegistrationModal.tsx
+++ b/src/components/RegistrationModal.tsx
@@ -74,7 +74,7 @@ const RegistrationModal = ({
         walletAddress,
         formValues.handle
       );
-      onIdResolved(core.identifiers.convertDSNPUserURIToDSNPUserId(userURI));
+      onIdResolved(core.identifiers.convertToDSNPUserId(userURI).toString());
     } catch (error) {
       console.error(error);
       setRegistrationError(
@@ -88,7 +88,7 @@ const RegistrationModal = ({
     registration: registry.Registration
   ): string | undefined =>
     profiles[
-      core.identifiers.convertDSNPUserURIToDSNPUserId(registration.dsnpUserURI)
+      core.identifiers.convertToDSNPUserId(registration.dsnpUserURI).toString()
     ]?.icon?.[0].href;
 
   /**

--- a/src/components/test/Login.test.tsx
+++ b/src/components/test/Login.test.tsx
@@ -37,7 +37,7 @@ beforeAll(async () => {
     .spyOn(dsnp, "getSocialIdentities")
     .mockImplementation(() =>
       Promise.resolve([
-        { dsnpUserURI: "dsnp://0x034b", contractAddr: "0xabc", handle: "test" },
+        { dsnpUserURI: "dsnp://4242", contractAddr: "0xabc", handle: "test" },
       ])
     );
 });

--- a/src/components/test/LoginSetupInstructions.test.tsx
+++ b/src/components/test/LoginSetupInstructions.test.tsx
@@ -27,7 +27,7 @@ beforeAll(async () => {
     .spyOn(dsnp, "getSocialIdentities")
     .mockImplementation(() =>
       Promise.resolve([
-        { dsnpUserURI: "dsnp://0x034b", contractAddr: "0xabc", handle: "test" },
+        { dsnpUserURI: "dsnp://4242", contractAddr: "0xabc", handle: "test" },
       ])
     );
 });

--- a/src/components/test/RegistrationModal.test.tsx
+++ b/src/components/test/RegistrationModal.test.tsx
@@ -47,7 +47,7 @@ describe("RegistrationModal", () => {
         .spyOn(dsnp, "createNewDSNPRegistration")
         .mockImplementation((_addr, handle) => {
           handleInput = handle;
-          return Promise.resolve("dsnp://0x424242");
+          return Promise.resolve("dsnp://424242");
         });
     });
 
@@ -85,7 +85,7 @@ describe("RegistrationModal", () => {
 
       await waitFor(() => {
         expect(handleInput).toBe("Joanne");
-        expect(registrationSelection).toBe("0x424242");
+        expect(registrationSelection).toBe("424242");
       });
     });
   });
@@ -189,7 +189,7 @@ describe("RegistrationModal", () => {
       it("permits a new registration", () => {
         const registerSpy = jest
           .spyOn(dsnp, "createNewDSNPRegistration")
-          .mockImplementation(() => Promise.resolve("dsnp://0x424242"));
+          .mockImplementation(() => Promise.resolve("dsnp://424242"));
 
         component.find("Input").simulate("change", {
           target: { value: "Joanne" },

--- a/src/redux/slices/graphSlice.ts
+++ b/src/redux/slices/graphSlice.ts
@@ -1,10 +1,9 @@
-import { DSNPUserId } from "@dsnp/sdk/dist/types/core/identifiers";
 import { createSlice, PayloadAction } from "@reduxjs/toolkit";
 import { GraphChange } from "../../utilities/types";
 
 interface graphState {
-  following: Record<DSNPUserId, Record<DSNPUserId, boolean>>;
-  followers: Record<DSNPUserId, Record<DSNPUserId, boolean>>;
+  following: Record<string, Record<string, boolean>>;
+  followers: Record<string, Record<string, boolean>>;
 }
 
 const initialState: graphState = {

--- a/src/redux/slices/userSlice.ts
+++ b/src/redux/slices/userSlice.ts
@@ -4,9 +4,9 @@ import * as session from "../../services/session";
 import { DSNPUserId } from "@dsnp/sdk/dist/types/core/identifiers";
 
 interface UserState {
-  id?: DSNPUserId;
+  id?: string;
   walletType: wallet.WalletType;
-  displayId?: DSNPUserId;
+  displayId?: string;
 }
 
 const initialState: UserState = {
@@ -27,8 +27,8 @@ export const userSlice = createSlice({
     }),
     userUpdateId: (state, action: PayloadAction<DSNPUserId>) => ({
       ...state,
-      id: action.payload,
-      displayId: action.payload,
+      id: action.payload.toString(),
+      displayId: action.payload.toString(),
     }),
     userUpdateWalletType: (
       state,
@@ -39,7 +39,7 @@ export const userSlice = createSlice({
     }),
     setDisplayId: (state, action: PayloadAction<DSNPUserId>) => ({
       ...state,
-      displayId: action.payload,
+      displayId: action.payload.toString(),
     }),
   },
 });

--- a/src/redux/slices/userSlice.ts
+++ b/src/redux/slices/userSlice.ts
@@ -11,6 +11,7 @@ interface UserState {
 
 const initialState: UserState = {
   id: session.hasSession() ? session.loadSession()?.id : undefined,
+  displayId: session.hasSession() ? session.loadSession()?.id : undefined,
   walletType: session.loadSession()?.walletType ?? wallet.WalletType.NONE,
 };
 

--- a/src/services/Storage.ts
+++ b/src/services/Storage.ts
@@ -30,7 +30,7 @@ export const createNote = async (
 export class Store implements StoreInterface {
   put(targetPath: string, _content: Content): Promise<URL> {
     return Promise.resolve(
-      new URL(`${buildBaseUploadHostUrl(true)}/${targetPath}`)
+      new URL(`${buildBaseUploadHostUrl()}/${targetPath}`)
     );
   }
 
@@ -40,7 +40,7 @@ export class Store implements StoreInterface {
   ): Promise<URL> {
     const ws = new ServerWriteStream(targetPath);
     await doWriteToStream(ws);
-    return new URL(`${buildBaseUploadHostUrl(true)}/${targetPath}`);
+    return new URL(`${buildBaseUploadHostUrl()}/${targetPath}`);
   }
 }
 
@@ -99,7 +99,7 @@ class ServerWriteStream implements WriteStream {
     }
 
     fetch(
-      `${buildBaseUploadHostUrl(false)}/upload?filename=${encodeURIComponent(
+      `${buildBaseUploadHostUrl()}/upload?filename=${encodeURIComponent(
         this.targetPath
       )}`,
       {

--- a/src/services/Storage.ts
+++ b/src/services/Storage.ts
@@ -8,13 +8,12 @@ import {
 import { isFunction, isUint8Array } from "./utilities";
 import { ActivityContentNote } from "@dsnp/sdk/core/activityContent";
 import { noteToActivityContentNote } from "../utilities/activityContent";
-import { DSNPUserId } from "@dsnp/sdk/dist/types/core/identifiers";
 import { buildBaseUploadHostUrl } from "../utilities/buildBaseUploadHostUrl";
 
 export const createNote = async (
   note: string,
   uriList: string[],
-  fromId: DSNPUserId | undefined
+  fromId: string
 ): Promise<FeedItem> => {
   // send content to api
   const activityPubNote: ActivityContentNote = noteToActivityContentNote(
@@ -22,7 +21,7 @@ export const createNote = async (
     uriList
   );
   const newPostFeedItem: Partial<FeedItem> = {
-    fromId: fromId,
+    fromId: BigInt(fromId),
     content: activityPubNote,
   };
   return newPostFeedItem;

--- a/src/services/content.ts
+++ b/src/services/content.ts
@@ -218,13 +218,9 @@ const dispatchProfile = (
  * handleRegistryUpdate dispatches a profile update for the handle when a registry update is made.
  * @param dispatch function used to dispatch to store
  * @param update registry log message containg DSNP uri and handle
- * @param blockNumber number of block containing the publication
- * @param blockIndex index of log message (relative to other DSNP logs) within the block
  */
 const handleRegistryUpdate = (dispatch: Dispatch) => (
-  update: RegistryUpdateLogData,
-  blockNumber: number,
-  blockIndex: number
+  update: RegistryUpdateLogData
 ) => {
   dispatch(
     upsertProfile({
@@ -233,9 +229,9 @@ const handleRegistryUpdate = (dispatch: Dispatch) => (
         .convertToDSNPUserId(update.dsnpUserURI)
         .toString(),
       handle: update.handle,
-      blockNumber,
-      blockIndex,
-      batchIndex: 0,
+      blockNumber: update.blockNumber,
+      blockIndex: update.transactionIndex,
+      batchIndex: 0, // batchIndex doesn't apply to registry updates
     })
   );
 };
@@ -295,11 +291,10 @@ const dispatchGraphChange = (
  * handleBatchAnnouncment retrieves and parses a batch and then routes its contents
  * to the redux store.
  * @param dispatch function used to dispatch to the store
- * @param blockIndex index of publication within block
+ * @param batchAnnouncement announcement of batch (publication) to handle
  */
 const handleBatchAnnouncement = (dispatch: Dispatch) => (
-  batchAnnouncement: BatchPublicationLogData,
-  blockIndex: number
+  batchAnnouncement: BatchPublicationLogData
 ) => {
   dsnp.readBatchFile(batchAnnouncement, (announcementRow, batchIndex) => {
     try {
@@ -311,7 +306,7 @@ const handleBatchAnnouncement = (dispatch: Dispatch) => (
           dispatch,
           announcement,
           batchAnnouncement.blockNumber,
-          blockIndex,
+          batchAnnouncement.transactionIndex,
           batchIndex++
         );
       }

--- a/src/services/dsnp.ts
+++ b/src/services/dsnp.ts
@@ -16,7 +16,6 @@ import { BatchPublicationLogData } from "@dsnp/sdk/core/contracts/subscription";
 import { WalletType } from "./wallets/wallet";
 import torusWallet from "./wallets/torus";
 import { DSNPUserId } from "@dsnp/sdk/dist/types/core/identifiers";
-import { UnsubscribeFunction } from "@dsnp/sdk/dist/types/core/contracts/utilities";
 
 //
 // DSNP Package
@@ -42,6 +41,8 @@ type AnnouncementRowHandler = (
   announcementRow: SignedAnnouncement,
   batchIndex: number
 ) => void;
+
+export type UnsubscribeFunction = () => void;
 
 //
 // Exported Functions

--- a/src/services/dsnp.ts
+++ b/src/services/dsnp.ts
@@ -26,16 +26,9 @@ import { DSNPUserId } from "@dsnp/sdk/dist/types/core/identifiers";
 // Parameter types
 //
 
-type RegistryUpdateHandler = (
-  update: RegistryUpdateLogData,
-  blockNumber: number,
-  blockIndex: number
-) => void;
+type RegistryUpdateHandler = (update: RegistryUpdateLogData) => void;
 
-type BatchAnnouncementHandler = (
-  announcment: BatchPublicationLogData,
-  blockIndex: number
-) => void;
+type BatchAnnouncementHandler = (announcment: BatchPublicationLogData) => void;
 
 type AnnouncementRowHandler = (
   announcementRow: SignedAnnouncement,
@@ -116,33 +109,17 @@ export const startSubscriptions = async (
   registryHandler: RegistryUpdateHandler
 ): Promise<UnsubscribeFunction> => {
   // subscribe to all announcements
-  let batchBlockNumber: number;
-  let batchBlockIndex = 0;
   const unsubscribeToBatchPublications = await core.contracts.subscription.subscribeToBatchPublications(
     (announcement: BatchPublicationLogData) => {
-      if (announcement.blockNumber !== batchBlockNumber) {
-        batchBlockNumber = announcement.blockNumber;
-        batchBlockIndex = 0;
-      } else {
-        batchBlockIndex++;
-      }
-      batchHandler(announcement, batchBlockIndex);
+      batchHandler(announcement);
     },
     { fromBlock: 1 }
   );
 
   // subscribe to registry events
-  let registryBlockNumber: number;
-  let registryBlockIndex = 0;
   const unsubscribeToRegistryUpdate = await core.contracts.subscription.subscribeToRegistryUpdates(
     (announcement: RegistryUpdateLogData) => {
-      if (announcement.blockNumber !== registryBlockNumber) {
-        registryBlockNumber = announcement.blockNumber;
-        registryBlockIndex = 0;
-      } else {
-        registryBlockIndex++;
-      }
-      registryHandler(announcement, registryBlockNumber, registryBlockIndex);
+      registryHandler(announcement);
     },
     { fromBlock: 1 }
   );

--- a/src/services/session.ts
+++ b/src/services/session.ts
@@ -2,7 +2,7 @@ import { DSNPUserId } from "@dsnp/sdk/dist/types/core/identifiers";
 import { WalletType } from "./wallets/wallet";
 
 interface SessionData {
-  id: DSNPUserId | undefined;
+  id: string | undefined;
   walletType: WalletType;
 }
 
@@ -38,7 +38,7 @@ export const upsertSessionUserId = (newId: DSNPUserId): void => {
     id: undefined,
     walletType: WalletType.NONE,
   };
-  saveSession({ ...curSession, id: newId });
+  saveSession({ ...curSession, id: newId.toString() });
 };
 
 export const hasSession = (): boolean => !!sessionStorage.getItem("session");

--- a/src/test/testGraphs.ts
+++ b/src/test/testGraphs.ts
@@ -1,4 +1,3 @@
-import { DSNPUserId } from "@dsnp/sdk/dist/types/core/identifiers";
 import { HexString } from "../utilities/types";
 import { generateDsnpUserId, getPrefabDsnpUserId } from "./testAddresses";
 
@@ -8,7 +7,7 @@ import { generateDsnpUserId, getPrefabDsnpUserId } from "./testAddresses";
  * for all users. The existence of a relationship from account1 to
  * account2 can be checked with graph[account1]?.[account2].
  */
-type Graph = Record<DSNPUserId, Record<DSNPUserId, boolean>>;
+type Graph = Record<string, Record<string, boolean>>;
 
 interface SocialGraph {
   followers: Graph;
@@ -18,7 +17,7 @@ interface SocialGraph {
 export const generateRandomGraph = (
   dsnpUserId: HexString,
   _size: number = 4
-): Record<DSNPUserId, boolean> => {
+): Record<string, boolean> => {
   return {};
 };
 
@@ -45,9 +44,9 @@ export const generateRandomSocialGraph = (
   graphSize: number = 4
 ): SocialGraph => {
   // Generate addresses
-  const following: Record<DSNPUserId, Record<DSNPUserId, boolean>> = {};
+  const following: Record<string, Record<string, boolean>> = {};
   for (let i = 0; i < socialGraphSize; i++) {
-    const address: DSNPUserId = generateDsnpUserId();
+    const address: string = generateDsnpUserId();
     const graph = generateRandomGraph(address, graphSize);
     following[address] = graph;
   }

--- a/src/test/testProfiles.ts
+++ b/src/test/testProfiles.ts
@@ -4,7 +4,6 @@ import { generateDsnpUserId, getPrefabDsnpUserId } from "./testAddresses";
 import { prefabFirstNames, prefabLastNames } from "./testhelpers";
 import { generators } from "@dsnp/sdk";
 import { ActivityContentProfile } from "@dsnp/sdk/core/activityContent";
-import { DSNPUserId } from "@dsnp/sdk/dist/types/core/identifiers";
 const generateProfile = generators.activityContent.generateProfile;
 
 /**
@@ -12,7 +11,7 @@ const generateProfile = generators.activityContent.generateProfile;
  * names and a generated social address
  */
 export const generateRandomProfile = (): ActivityContentProfile & {
-  fromId: DSNPUserId;
+  fromId: string;
 } => {
   const fromId = generateDsnpUserId();
   const firstName = prefabFirstNames[randInt(prefabFirstNames.length)];
@@ -30,7 +29,7 @@ export const generateRandomProfile = (): ActivityContentProfile & {
  */
 export const getPrefabProfile = (
   index: number
-): ActivityContentProfile & { fromId: DSNPUserId } => {
+): ActivityContentProfile & { fromId: string } => {
   return preFabProfiles[index];
 };
 
@@ -40,7 +39,7 @@ export const getPrefabProfile = (
  */
 export const preFabProfiles: Array<
   ActivityContentProfile & {
-    fromId: DSNPUserId;
+    fromId: string;
   }
 > = [
   {
@@ -75,7 +74,7 @@ export const preFabProfiles: Array<
 
 export const getPrefabProfileByAddress = (
   address: HexString
-): (ActivityContentProfile & { fromId: DSNPUserId }) | null => {
+): (ActivityContentProfile & { fromId: string }) | null => {
   for (let i = 0; i < preFabProfiles.length; i++) {
     const prefabProfile = preFabProfiles[i];
     if (prefabProfile.fromId === address) {

--- a/src/utilities/buildBaseUploadHostUrl.test.ts
+++ b/src/utilities/buildBaseUploadHostUrl.test.ts
@@ -27,14 +27,14 @@ describe("buildBaseUploadHostUrl", () => {
       },
     }));
 
-    process.env.REACT_APP_UPLOAD_HOST = "/test";
-
     it("returns a qualified url for REACT_APP_UPLOAD_HOST", () => {
-      expect(buildBaseUploadHostUrl(true)).toEqual("http://example.com//test");
+      process.env.REACT_APP_UPLOAD_HOST = "";
+      expect(buildBaseUploadHostUrl()).toEqual("http://example.com");
     });
 
     it("does not return a qualified url for REACT_APP_UPLOAD_HOST", () => {
-      expect(buildBaseUploadHostUrl(false)).toEqual("/test");
+      process.env.REACT_APP_UPLOAD_HOST = "http://localhost:3000";
+      expect(buildBaseUploadHostUrl()).toEqual("http://localhost:3000");
     });
   });
 });

--- a/src/utilities/buildBaseUploadHostUrl.ts
+++ b/src/utilities/buildBaseUploadHostUrl.ts
@@ -1,5 +1,5 @@
-export const buildBaseUploadHostUrl = (qualifiedUrl: boolean): string => {
-  return qualifiedUrl
-    ? `${window.location.host}/${process.env.REACT_APP_UPLOAD_HOST}`
-    : `${process.env.REACT_APP_UPLOAD_HOST}`;
+export const buildBaseUploadHostUrl = (): string => {
+  return process.env.REACT_APP_UPLOAD_HOST
+    ? process.env.REACT_APP_UPLOAD_HOST
+    : window.location.host;
 };

--- a/src/utilities/buildBaseUploadHostUrl.ts
+++ b/src/utilities/buildBaseUploadHostUrl.ts
@@ -1,5 +1,3 @@
 export const buildBaseUploadHostUrl = (): string => {
-  return process.env.REACT_APP_UPLOAD_HOST
-    ? process.env.REACT_APP_UPLOAD_HOST
-    : window.location.host;
+  return process.env.REACT_APP_UPLOAD_HOST || window.location.host;
 };

--- a/src/utilities/types.d.ts
+++ b/src/utilities/types.d.ts
@@ -6,14 +6,24 @@ export declare type HexString = string;
 
 // ## GraphChange ##
 export interface GraphChange {
-  followee: DSNPUserId;
-  follower: DSNPUserId;
+  followee: string;
+  follower: string;
   unfollow: boolean;
 }
 
 // ## Profile ##
-export type Profile = ProfileAnnouncement &
-  ActivityContentProfile & { handle: string, blockNumber: number, blockIndex: number, batchIndex: number };
+export type Profile = {
+  fromId: string;
+  contentHash?: HexString;
+  url?: string;
+  summary?: string;
+  icon?: Array<ActivityContentImageLink>;
+  name?: string;
+  handle?: string;
+  blockNumber: number;
+  blockIndex: number;
+  batchIndex: number;
+};
 
 // ## FeedItem ##
 export type FeedItem = BroadcastAnnouncement & ActivityContentNote;


### PR DESCRIPTION
Purpose
---------------
Significant breaking changes were made in SDK 3.0. This PR makes necessary changes to incorporate these changes.


Solution
---------------
The SDK now returning DSNPUserId as a BigInt drives most of the changes in this PR. BigInt is not serializable, so it can't be stored in Redux and it cannot be used as a map key. Our approach is to convert all id's to strings (as they were before) before storing them and occasionally converting them back when submitting content back to the SDK. 

One of the bigger changes is that we now create a completely new `Profile` type to be used within the example-client rather than union-ing SDK types and adding fields. This allows us to normalize some behavior between registry updates and profile upgrades. 

We also take advantage of some of the new utility functions the SDK provides. 

Change summary
---------------
* Upgrade to SDK 3.0
* Refactor to convert DSNPUserId to strings
* Refactor Profile type
* Fix tests


Steps to Verify
----------------
1. This is a pure refactor. No behavior should have changed.
