### PR TITLE
add protocol to base url

### DIFF
--- a/src/utilities/buildBaseUploadHostUrl.test.ts
+++ b/src/utilities/buildBaseUploadHostUrl.test.ts
@@ -23,7 +23,8 @@ describe("buildBaseUploadHostUrl", () => {
       ...originalWindow,
       location: {
         ...originalWindow.location,
-        host: "http://example.com",
+        host: "example.com",
+        protocol: "http:",
       },
     }));
 

--- a/src/utilities/buildBaseUploadHostUrl.ts
+++ b/src/utilities/buildBaseUploadHostUrl.ts
@@ -1,3 +1,6 @@
 export const buildBaseUploadHostUrl = (): string => {
-  return process.env.REACT_APP_UPLOAD_HOST || window.location.host;
+  return (
+    process.env.REACT_APP_UPLOAD_HOST ||
+    `${window.location.protocol}//${window.location.host}`
+  );
 };


### PR DESCRIPTION
Purpose
---------------
Bug - the protocol is missing from `window.location` - so we need to add it to retrieve the appropriate fully qualified url.

Solution
---------------
Add `window.protocol` to `window.location` in `buildBaseUploadHostUrl`


Change summary
---------------
* add protocol to `window.location` in `buildBaseUploadHostUrl`
* fix spec.
