### PR TITLE
show other's posts in feed + tests

### DIFF
--- a/src/components/Feed.tsx
+++ b/src/components/Feed.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useEffect, useState } from "react";
 import NewPost from "./NewPost";
 import PostList from "./PostList";
 import { Button } from "antd";
@@ -11,7 +11,7 @@ enum FeedTypes {
   MY_FEED,
   MY_POSTS,
   DISCOVER,
-  PROFILE_POSTS,
+  DISPLAY_ID_POSTS,
 }
 
 const Feed = (): JSX.Element => {
@@ -29,25 +29,41 @@ const Feed = (): JSX.Element => {
 
   const [isModalOpen, setIsModalOpen] = useState<boolean>(false);
   const [feedType, setFeedType] = useState<FeedTypes>(FeedTypes.DISCOVER);
+  const [showDisplayIdNav, setShowDisplayIdNav] = useState<boolean>(false);
 
   const feedNavClassName = (navItemType: FeedTypes) =>
     feedType === navItemType
       ? "Feed__navigationItem Feed__navigationItem--active"
       : "Feed__navigationItem";
 
+  const resetFeed = () => {
+    userId && dispatch(setDisplayId(userId));
+    setShowDisplayIdNav(false);
+    setFeedType(FeedTypes.DISCOVER);
+  };
+
+  useEffect(() => {
+    if (!(userId && displayId && displayId !== userId)) return;
+    setShowDisplayIdNav(true);
+  }, [userId, displayId]);
+
+  useEffect(() => {
+    showDisplayIdNav && setFeedType(FeedTypes.DISPLAY_ID_POSTS);
+  }, [showDisplayIdNav, displayId]);
+
   return (
     <div className="Feed__block">
       <div className="Feed__header">
         <nav className="Feed__navigation">
-          {userId && displayId && displayId !== userId && (
+          {showDisplayIdNav && (
             <>
-              <div
-                className="Feed__backArrow"
-                onClick={() => dispatch(setDisplayId(BigInt(userId)))}
-              >
+              <div className="Feed__backArrow" onClick={() => resetFeed()}>
                 <ArrowLeftOutlined />
               </div>
-              <div className={feedNavClassName(FeedTypes.PROFILE_POSTS)}>
+              <div
+                className={feedNavClassName(FeedTypes.DISPLAY_ID_POSTS)}
+                onClick={() => setFeedType(FeedTypes.DISPLAY_ID_POSTS)}
+              >
                 {profile?.name || profile?.handle}'s Posts
               </div>
               <div className="Feed__navigationSpacer"></div>

--- a/src/components/Login.tsx
+++ b/src/components/Login.tsx
@@ -34,7 +34,7 @@ const Login = ({ isPrimary, loginWalletOptions }: LoginProps): JSX.Element => {
 
   const setUserID = (fromURI: string) => {
     const fromId = core.identifiers.convertToDSNPUserId(fromURI);
-    dispatch(userUpdateId(fromId));
+    dispatch(userUpdateId(fromId.toString()));
     session.upsertSessionUserId(fromId);
     setRegistrationVisible(false);
   };

--- a/src/components/PostList.tsx
+++ b/src/components/PostList.tsx
@@ -12,7 +12,7 @@ enum FeedTypes {
   MY_FEED,
   MY_POSTS,
   DISCOVER,
-  PROFILE_POSTS,
+  DISPLAY_ID_POSTS,
 }
 
 interface PostListProps {
@@ -28,7 +28,9 @@ const sortFeed = (feed: FeedItem[]): FeedItem[] => {
 };
 
 const PostList = ({ feedType }: PostListProps): JSX.Element => {
-  const userId: string | undefined = useAppSelector((state) => state.user.id);
+  const { id: userId, displayId }: any | undefined = useAppSelector(
+    (state) => state.user
+  );
   const myGraph: Record<string, RelationshipState> = useAppSelector(
     (state) => (userId && state.graphs.following[userId]) || {}
   );
@@ -54,6 +56,8 @@ const PostList = ({ feedType }: PostListProps): JSX.Element => {
     );
   } else if (feedType === FeedTypes.MY_POSTS) {
     currentFeed = feed.filter((post) => userId === post?.fromId);
+  } else if (feedType === FeedTypes.DISPLAY_ID_POSTS) {
+    currentFeed = feed.filter((post) => displayId === post?.fromId);
   } else {
     currentFeed = feed;
   }

--- a/src/components/PostList.tsx
+++ b/src/components/PostList.tsx
@@ -28,8 +28,9 @@ const sortFeed = (feed: FeedItem[]): FeedItem[] => {
 };
 
 const PostList = ({ feedType }: PostListProps): JSX.Element => {
-  const { id: userId, displayId }: any | undefined = useAppSelector(
-    (state) => state.user
+  const userId: string | undefined = useAppSelector((state) => state.user.id);
+  const displayId: string | undefined = useAppSelector(
+    (state) => state.user.displayId
   );
   const myGraph: Record<string, RelationshipState> = useAppSelector(
     (state) => (userId && state.graphs.following[userId]) || {}

--- a/src/components/test/Feed.test.tsx
+++ b/src/components/test/Feed.test.tsx
@@ -6,7 +6,6 @@ import { componentWithStore, createMockStore } from "../../test/testhelpers";
 import { getPreFabSocialGraph } from "../../test/testGraphs";
 import { getPrefabProfile } from "../../test/testProfiles";
 import { FeedItem } from "../../utilities/types";
-import { waitFor } from "@testing-library/react";
 
 const userProfile = getPrefabProfile(0);
 const displayProfile = getPrefabProfile(3);
@@ -66,7 +65,7 @@ describe("Feed", () => {
   });
 
   describe("Displays Correct Feed", () => {
-    it("Connections Feed", () => {
+    it("Discover Feed", () => {
       const component = mount(componentWithStore(Feed, store));
       const button = component.findWhere((node) => {
         return (
@@ -86,7 +85,7 @@ describe("Feed", () => {
       });
     });
 
-    it("My Feed", () => {
+    it("My Posts", () => {
       const component = mount(componentWithStore(Feed, store));
       const button = component.findWhere((node) => {
         return (
@@ -100,7 +99,7 @@ describe("Feed", () => {
       });
     });
 
-    it("All Posts", () => {
+    it("My Feed", () => {
       const component = mount(componentWithStore(Feed, store));
       const button = component.findWhere((node) => {
         return (
@@ -114,38 +113,16 @@ describe("Feed", () => {
     describe("Another User's Posts", () => {
       it("Displays nav name in feed nav", async () => {
         const component = mount(componentWithStore(Feed, store));
-        const postProfileBlock = component.findWhere((node) =>
-          node.hasClass("Post__metaBlock")
+        expect(component.find(".Feed__navigationItem--active").text()).toEqual(
+          displayProfile.name + "'s Posts"
         );
-        postProfileBlock.first().simulate("click");
-        try {
-          await waitFor(() => {
-            expect(
-              component.find(".Feed__navigationItem--active").text()
-            ).toEqual(displayProfile.name + "'s Posts");
-          });
-        } catch (e) {
-          console.log("error", component.debug());
-          throw e;
-        }
       });
 
       it("Displays correct feed items", async () => {
         const component = mount(componentWithStore(Feed, store));
-        const postProfileBlock = component.findWhere((node) =>
-          node.hasClass("Post__metaBlock")
+        expect(component.find(Post).props().feedItem.fromId).toEqual(
+          displayProfile.fromId
         );
-        postProfileBlock.first().simulate("click");
-        try {
-          await waitFor(() => {
-            expect(component.find(Post).props().feedItem.fromId).toEqual(
-              displayProfile.fromId
-            );
-          });
-        } catch (e) {
-          console.log("error", component.debug());
-          throw e;
-        }
       });
     });
   });

--- a/src/redux/slices/userSlice.ts
+++ b/src/redux/slices/userSlice.ts
@@ -37,13 +37,10 @@ export const userSlice = createSlice({
       ...state,
       walletType: action.payload,
     }),
-    setDisplayId: (state, action: PayloadAction<string>) => {
-      console.log("in redux store:", action.payload);
-      return {
-        ...state,
-        displayId: action.payload,
-      };
-    },
+    setDisplayId: (state, action: PayloadAction<string>) => ({
+      ...state,
+      displayId: action.payload,
+    }),
   },
 });
 export const {

--- a/src/redux/slices/userSlice.ts
+++ b/src/redux/slices/userSlice.ts
@@ -1,7 +1,6 @@
 import { createSlice, PayloadAction } from "@reduxjs/toolkit";
 import * as wallet from "../../services/wallets/wallet";
 import * as session from "../../services/session";
-import { DSNPUserId } from "@dsnp/sdk/dist/types/core/identifiers";
 
 interface UserState {
   id?: string;
@@ -26,10 +25,10 @@ export const userSlice = createSlice({
     userLogout: (_state) => ({
       walletType: wallet.WalletType.NONE,
     }),
-    userUpdateId: (state, action: PayloadAction<DSNPUserId>) => ({
+    userUpdateId: (state, action: PayloadAction<string>) => ({
       ...state,
-      id: action.payload.toString(),
-      displayId: action.payload.toString(),
+      id: action.payload,
+      displayId: action.payload,
     }),
     userUpdateWalletType: (
       state,
@@ -38,10 +37,13 @@ export const userSlice = createSlice({
       ...state,
       walletType: action.payload,
     }),
-    setDisplayId: (state, action: PayloadAction<DSNPUserId>) => ({
-      ...state,
-      displayId: action.payload.toString(),
-    }),
+    setDisplayId: (state, action: PayloadAction<string>) => {
+      console.log("in redux store:", action.payload);
+      return {
+        ...state,
+        displayId: action.payload,
+      };
+    },
   },
 });
 export const {

--- a/src/test/testAddresses.ts
+++ b/src/test/testAddresses.ts
@@ -29,7 +29,7 @@ export const getPrefabWalletAddress = (index: number): HexString => {
  * Get a prefabricated social identity address compatible with other prefab data
  * Prefab social identity addres is `0xCODE0000`
  */
-export const getPrefabDsnpUserId = (index: number): HexString => {
+export const getPrefabDsnpUserId = (index: number): string => {
   const regex = /0/gi;
   const address = "12340000".replace(regex, index.toString());
   return address;

--- a/src/test/testProfiles.ts
+++ b/src/test/testProfiles.ts
@@ -1,5 +1,4 @@
 import { randInt } from "@dsnp/test-generators";
-import { HexString } from "../utilities/types";
 import { generateDsnpUserId, getPrefabDsnpUserId } from "./testAddresses";
 import { prefabFirstNames, prefabLastNames } from "./testhelpers";
 import { generators } from "@dsnp/sdk";
@@ -73,7 +72,7 @@ export const preFabProfiles: Array<
 ];
 
 export const getPrefabProfileByAddress = (
-  address: HexString
+  address: string | undefined
 ): (ActivityContentProfile & { fromId: string }) | null => {
   for (let i = 0; i < preFabProfiles.length; i++) {
     const prefabProfile = preFabProfiles[i];


### PR DESCRIPTION
Purpose
---------------
[https://www.pivotaltracker.com/story/show/177349009](url)
feature



Solution
---------------
As a user, I want to click on a profile, see their profile information in the profile component, and see their posts in the feed component.
- Filter feed to only the selected user's posts
- follow wireframes for styling


Change summary
---------------
* onclick of a user's profile, display their feed in addition to their profile
* update redux store to not throw a console error (leftover from main)
* write new tests for new functionality
* correct old failing tests

Steps to Verify
----------------
1. click on others profile
2. see their profile
3. see their posts
4. see their name as the active tab in feed nav
5. click back button
6. go back to discover and my profile
7. click on another user
8. click on a second other user
9. see the name and feeds switch as expected


Additional details / screenshot
----------------

https://user-images.githubusercontent.com/43625033/132425315-6ad96aee-7f80-4f77-8309-074de758908e.mov


