### PR TITLE
changes made to storing batch announcements and note attchment typing

### DIFF
--- a/src/components/Post.tsx
+++ b/src/components/Post.tsx
@@ -6,10 +6,10 @@ import PostMedia from "./PostMedia";
 import RelativeTime from "./RelativeTime";
 import ReplyBlock from "./ReplyBlock";
 import PostHashDropdown from "./PostHashDropdown";
-import { ActivityContentImage } from "@dsnp/sdk/core/activityContent";
 import { FromTitle } from "./FromTitle";
 import { setDisplayId } from "../redux/slices/userSlice";
 import { useAppDispatch, useAppSelector } from "../redux/hooks";
+import { ActivityContentAttachment } from "@dsnp/sdk/core/activityContent";
 
 interface PostProps {
   feedItem: FeedItem;
@@ -19,7 +19,7 @@ const Post = ({ feedItem }: PostProps): JSX.Element => {
   const dispatch = useAppDispatch();
 
   const noteContent = feedItem.content;
-  const attachments = noteContent.attachment;
+  const attachments: ActivityContentAttachment[] = noteContent.attachment || [];
 
   const [isHoveringProfile, setIsHoveringProfile] = useState(false);
 
@@ -65,9 +65,7 @@ const Post = ({ feedItem }: PostProps): JSX.Element => {
       </div>
       <PostHashDropdown hash={feedItem.hash} fromId={feedItem.fromId} />
       <div className="Post__caption">{noteContent.content}</div>
-      {attachments && (
-        <PostMedia attachment={attachments as ActivityContentImage[]} />
-      )}
+      {attachments && <PostMedia attachments={attachments} />}
       <ReplyBlock parent={feedItem.hash} />
     </Card>
   );

--- a/src/components/PostList.tsx
+++ b/src/components/PostList.tsx
@@ -62,7 +62,6 @@ const PostList = ({ feedType }: PostListProps): JSX.Element => {
   } else {
     currentFeed = feed;
   }
-
   return (
     <div className="PostList__block">
       {loading && <BlankPost />}

--- a/src/components/PostMedia.tsx
+++ b/src/components/PostMedia.tsx
@@ -10,39 +10,53 @@ import {
 } from "@dsnp/sdk/core/activityContent";
 
 interface PostMediaProps {
-  attachment: ActivityContentAttachment[];
+  attachments: ActivityContentAttachment[];
 }
 
-const PostMedia = ({ attachment }: PostMediaProps): JSX.Element => {
+function isImage(
+  attachment: ActivityContentAttachment
+): attachment is ActivityContentImage {
+  return attachment.type.toLowerCase() === "image";
+}
+
+function isVideo(
+  attachment: ActivityContentAttachment
+): attachment is ActivityContentVideo {
+  return attachment.type.toLowerCase() === "video";
+}
+
+function isAudio(
+  attachment: ActivityContentAttachment
+): attachment is ActivityContentAudio {
+  return attachment.type.toLowerCase() === "audio";
+}
+
+const PostMedia = ({ attachments }: PostMediaProps): JSX.Element => {
   const getPostMediaItems = () => {
-    return attachment.map((item, index) => {
-      const type = item?.type?.toLowerCase();
+    return attachments.map((attachment, index) => {
       return (
         <div key={index} className="PostMedia__cover">
-          {type === "image" && (
+          {isImage(attachment) && (
             <a
-              href={(item as ActivityContentImage).url[0].href}
+              href={attachment.url[0].href}
               target="_blank"
               rel="noopener noreferrer"
             >
               <img
-                alt={item.name}
+                alt={attachment.name}
                 className="PostMedia__img"
-                src={(item as ActivityContentImage).url[0].href}
+                src={attachment.url[0].href}
               />
             </a>
           )}
-          {(type === "video" || type === "audio") && (
+          {(isVideo(attachment) || isAudio(attachment)) && (
             <ReactPlayer
               controls
               playsinline
               className="PostMedia__img"
-              url={
-                (item as ActivityContentVideo | ActivityContentAudio).url[0]
-                  .href
-              }
+              url={attachment.url[0].href}
               width={670}
-              height={type === "video" ? 400 : 55}
+              height={isVideo(attachment) ? 400 : 55}
               muted
             />
           )}

--- a/src/services/content.ts
+++ b/src/services/content.ts
@@ -173,17 +173,12 @@ const dispatchActivityContent = (
   batchIndex: number
 ) => {
   if (isActivityContentNoteType(activityContent)) {
-    return dispatchFeedItem(
-      dispatch,
-      message,
-      activityContent as ActivityContentNote,
-      blockNumber
-    );
+    return dispatchFeedItem(dispatch, message, activityContent, blockNumber);
   } else if (isActivityContentProfileType(activityContent)) {
     return dispatchProfile(
       dispatch,
       message,
-      activityContent as ActivityContentProfile,
+      activityContent,
       blockNumber,
       blockIndex,
       batchIndex

--- a/src/services/dsnp.ts
+++ b/src/services/dsnp.ts
@@ -195,7 +195,7 @@ export const batchAnnouncement = async (
 
   await core.contracts.publisher.publish([
     {
-      announcementType: core.announcements.AnnouncementType.Broadcast,
+      announcementType: announcement.announcementType,
       fileUrl: batchData.url.toString(),
       fileHash: batchData.hash,
     },

--- a/src/utilities/types.d.ts
+++ b/src/utilities/types.d.ts
@@ -1,7 +1,3 @@
-import { ProfileAnnouncement } from "@dsnp/sdk/core/announcements";
-import { ActivityContentProfile } from "@dsnp/sdk/core/activityContent";
-import { DSNPUserId } from "@dsnp/sdk/dist/types/core/identifiers";
-
 export declare type HexString = string;
 
 // ## GraphChange ##


### PR DESCRIPTION
Purpose
---------------
[https://www.pivotaltracker.com/story/show/179376055](url)

Currently, on QA the loading of the feed fails because we are unsafely casting to the type of ActivityContentAttachment[] when somehow one of the pieces of data on QAnet has a null.

Solution
---------------
* We should be safely casting the content to the Activity Content type by validating the content and using a type narrowing is so that we can trust our types.

Change summary
---------------
- change the way that we are storying the type of batch announcements to be the correct type instead of storing them all as broadcasts.
- update types to stop using "as ..." and instead type check using "is"

Steps to Verify
----------------
1. make sure that null data coming through QA net does not throw an error anymore.
