### PR TITLE
on chain id change, logout

### DIFF
--- a/src/components/Login.tsx
+++ b/src/components/Login.tsx
@@ -93,6 +93,8 @@ const Login = ({ isPrimary, loginWalletOptions }: LoginProps): JSX.Element => {
       .on("accountsChanged", handleAccountsChange);
   }
 
+  ethereum?.removeAllListeners("chainChanged").on("chainChanged", logout);
+
   return (
     <div className="Login__block">
       {!userId ? (


### PR DESCRIPTION
Purpose
---------------
feature
restart of [https://www.pivotaltracker.com/story/show/179380420](url)


Solution
---------------
Add listener for chain Changed and logout on event.

Change summary
---------------
* add `chainChanged` listener


Steps to Verify
----------------
1. login
2. change networks
3. see logout happen

Additional details / screenshot
----------------
- the network change listener is deprecated, so this is the one that is the closest fitting.  is there a case in which the network changes but the chain id does not? [https://docs.metamask.io/guide/ethereum-provider.html#table-of-contents](url)