### PR TITLE
authorize announcement messages before dispatching

### DIFF
--- a/src/services/content.ts
+++ b/src/services/content.ts
@@ -259,7 +259,7 @@ const handleRegistryUpdate = (dispatch: Dispatch) => (
 const handleBatchAnnouncement = (dispatch: Dispatch) => (
   batchAnnouncement: BatchPublicationLogData
 ) => {
-  dsnp.readBatchFile(batchAnnouncement, (announcementRow, batchIndex) => {
+  dsnp.readBatchFile(batchAnnouncement, async (announcementRow, batchIndex) => {
     try {
       const announcement = announcementRow as unknown;
 
@@ -272,12 +272,12 @@ const handleBatchAnnouncement = (dispatch: Dispatch) => (
       }
 
       if (
-        !core.contracts.registry.isSignatureAuthorizedTo(
+        !(await core.contracts.registry.isSignatureAuthorizedTo(
           announcement.signature,
           announcement,
           BigInt(announcement.fromId),
           Permission.ANNOUNCE
-        )
+        ))
       ) {
         console.log(
           "batched announcment has unauthorized signature",
@@ -298,8 +298,6 @@ const handleBatchAnnouncement = (dispatch: Dispatch) => (
           })
         );
       } else if (isBroadcastAnnouncement(announcement)) {
-        console.log("broadcast annoucement url", announcement.url);
-        console.log("broadcast annoucement hash", announcement.contentHash);
         dispatch(
           addFeedItem({
             fromId: announcement.fromId.toString(),

--- a/src/services/content.ts
+++ b/src/services/content.ts
@@ -20,6 +20,7 @@ import {
   isGraphChangeAnnouncement,
   isProfileAnnouncement,
   isReplyAnnouncement,
+  isSignedAnnouncement,
 } from "@dsnp/sdk/core/announcements";
 import { BatchPublicationLogData } from "@dsnp/sdk/core/contracts/subscription";
 import { upsertGraph } from "../redux/slices/graphSlice";
@@ -29,6 +30,7 @@ import { HexString } from "@dsnp/sdk/types/Strings";
 import { DSNPAnnouncementURI, DSNPUserId } from "@dsnp/sdk/core/identifiers";
 import { FeedItem, User } from "../utilities/types";
 import { useQuery, UseQueryResult } from "react-query";
+import { Permission } from "@dsnp/sdk/core/contracts/identity";
 
 //
 // Content Package
@@ -260,6 +262,30 @@ const handleBatchAnnouncement = (dispatch: Dispatch) => (
   dsnp.readBatchFile(batchAnnouncement, (announcementRow, batchIndex) => {
     try {
       const announcement = announcementRow as unknown;
+
+      if (!isSignedAnnouncement(announcement)) {
+        console.log(
+          "batched announcement is not signed announcment",
+          announcement
+        );
+        return;
+      }
+
+      if (
+        !core.contracts.registry.isSignatureAuthorizedTo(
+          announcement.signature,
+          announcement,
+          BigInt(announcement.fromId),
+          Permission.ANNOUNCE
+        )
+      ) {
+        console.log(
+          "batched announcment has unauthorized signature",
+          announcement
+        );
+        return;
+      }
+
       if (isGraphChangeAnnouncement(announcement)) {
         dispatch(
           upsertGraph({
@@ -272,6 +298,8 @@ const handleBatchAnnouncement = (dispatch: Dispatch) => (
           })
         );
       } else if (isBroadcastAnnouncement(announcement)) {
+        console.log("broadcast annoucement url", announcement.url);
+        console.log("broadcast annoucement hash", announcement.contentHash);
         dispatch(
           addFeedItem({
             fromId: announcement.fromId.toString(),


### PR DESCRIPTION
Purpose
---------------
The example client should not accept improperly signed announcements. This PR rectifies that.
I needed to check that EC was sending valid signatures, and adding this authorization was the easiest way. Now that it's there I don't see any reason to get rid of it.

Solution
---------------
Add check to ignore announcements if a) they're not SignedAnnocements b) their signature does not resolve to a designated authority with announce privileges on chain. 

Change summary
---------------
* Add checks described above.

Steps to Verify
----------------
1. Should work the same as it used to.
2. You can modify the code to produce a bad signature and confirm an error appears in the console and the post does not appear in the feed.
