### PR TITLE
Update SDK package to v3.0.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@dsnp/contracts": "1.0.1",
         "@dsnp/parquetjs": "^1.1.0",
-        "@dsnp/sdk": "^3.0.2",
+        "@dsnp/sdk": "^3.0.3",
         "@reduxjs/toolkit": "^1.5.1",
         "@toruslabs/torus-embed": "1.9.2",
         "antd": "^4.3.1",
@@ -2041,9 +2041,9 @@
       }
     },
     "node_modules/@dsnp/sdk": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/@dsnp/sdk/-/sdk-3.0.2.tgz",
-      "integrity": "sha512-JK6r46Q3piTjp2OBFShx8HI3qmJkQmfumMDvprpMhwi/YQBgqPstQr0QgSjrIksBXfC+nRwSO1iTIsATm7VRAQ==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@dsnp/sdk/-/sdk-3.0.3.tgz",
+      "integrity": "sha512-4kq/5g8U8XDM6NZ5xe7osUwwB6ETgYliKl/88RyRSmYYIg5YBRr72S87ANk1X/0Mf7EvRPI39892EThfUXWC/Q==",
       "dependencies": {
         "@dsnp/contracts": "1.0.1",
         "@dsnp/parquetjs": "^1.1.2",
@@ -36890,9 +36890,9 @@
       }
     },
     "@dsnp/sdk": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/@dsnp/sdk/-/sdk-3.0.2.tgz",
-      "integrity": "sha512-JK6r46Q3piTjp2OBFShx8HI3qmJkQmfumMDvprpMhwi/YQBgqPstQr0QgSjrIksBXfC+nRwSO1iTIsATm7VRAQ==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@dsnp/sdk/-/sdk-3.0.3.tgz",
+      "integrity": "sha512-4kq/5g8U8XDM6NZ5xe7osUwwB6ETgYliKl/88RyRSmYYIg5YBRr72S87ANk1X/0Mf7EvRPI39892EThfUXWC/Q==",
       "requires": {
         "@dsnp/contracts": "1.0.1",
         "@dsnp/parquetjs": "^1.1.2",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "dependencies": {
     "@dsnp/contracts": "1.0.1",
     "@dsnp/parquetjs": "^1.1.0",
-    "@dsnp/sdk": "^3.0.2",
+    "@dsnp/sdk": "^3.0.3",
     "@reduxjs/toolkit": "^1.5.1",
     "@toruslabs/torus-embed": "1.9.2",
     "antd": "^4.3.1",

--- a/src/components/ConnectionsListProfiles.tsx
+++ b/src/components/ConnectionsListProfiles.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import UserAvatar from "./UserAvatar";
 import { User } from "../utilities/types";
-import { HexString } from "@dsnp/sdk/dist/types/types/Strings";
+import { HexString } from "@dsnp/sdk/types/Strings";
 import { useAppSelector } from "../redux/hooks";
 import { AnnouncementType } from "@dsnp/sdk/core/announcements";
 import {

--- a/src/components/RegistrationModal.tsx
+++ b/src/components/RegistrationModal.tsx
@@ -6,7 +6,7 @@ import * as dsnp from "../services/dsnp";
 import * as registry from "@dsnp/sdk/core/contracts/registry";
 import { HexString } from "../utilities/types";
 import { Registration } from "@dsnp/sdk/core/contracts/registry";
-import { DSNPUserURI } from "@dsnp/sdk/dist/types/core/identifiers";
+import { DSNPUserURI } from "@dsnp/sdk/core/identifiers";
 
 interface RegistrationModalProps {
   children: JSX.Element;

--- a/src/components/test/RegistrationModal.test.tsx
+++ b/src/components/test/RegistrationModal.test.tsx
@@ -4,7 +4,7 @@ import { componentWithStore, createMockStore } from "../../test/testhelpers";
 import { getPrefabProfile } from "../../test/testProfiles";
 import { waitFor } from "@testing-library/react";
 import { Registration } from "@dsnp/sdk/core/contracts/registry";
-import { DSNPUserURI } from "@dsnp/sdk/dist/types/core/identifiers";
+import { DSNPUserURI } from "@dsnp/sdk/core/identifiers";
 import * as dsnp from "../../services/dsnp";
 
 const profiles = Array(3)

--- a/src/services/content.ts
+++ b/src/services/content.ts
@@ -25,7 +25,7 @@ import { BatchPublicationLogData } from "@dsnp/sdk/core/contracts/subscription";
 import { upsertGraph } from "../redux/slices/graphSlice";
 import * as dsnp from "./dsnp";
 import { keccak256 } from "web3-utils";
-import { HexString } from "@dsnp/sdk/dist/types/types/Strings";
+import { HexString } from "@dsnp/sdk/types/Strings";
 import { DSNPAnnouncementURI, DSNPUserId } from "@dsnp/sdk/core/identifiers";
 import { FeedItem, User } from "../utilities/types";
 import { useQuery, UseQueryResult } from "react-query";

--- a/src/services/dsnp.ts
+++ b/src/services/dsnp.ts
@@ -13,7 +13,7 @@ import {
 import { BatchPublicationLogData } from "@dsnp/sdk/core/contracts/subscription";
 import { WalletType } from "./wallets/wallet";
 import torusWallet from "./wallets/torus";
-import { DSNPUserId } from "@dsnp/sdk/dist/types/core/identifiers";
+import { DSNPUserId } from "@dsnp/sdk/core/identifiers";
 
 //
 // DSNP Package

--- a/src/services/session.ts
+++ b/src/services/session.ts
@@ -1,4 +1,4 @@
-import { DSNPUserId } from "@dsnp/sdk/dist/types/core/identifiers";
+import { DSNPUserId } from "@dsnp/sdk/core/identifiers";
 import { WalletType } from "./wallets/wallet";
 
 interface SessionData {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -15,5 +15,5 @@
     "noEmit": true,
     "jsx": "preserve"
   },
-  "include": ["src", "src/utilities/svg.d.ts"]
+  "include": ["src"]
 }


### PR DESCRIPTION
Purpose
---------------
We were using an old version of the sdk

[PT #179426683](https://www.pivotaltracker.com/story/show/179426683)

Solution
---------------
Update to v3.0.3


Change summary
---------------
* Update SDK from v3.0.2 -> 3.0.3
* Use `HexString` from the SDK
* Replace sdk/dist/types with just sdk
