### PR TITLE
Bugs/fix url 179612435

### DIFF
--- a/src/services/Storage.ts
+++ b/src/services/Storage.ts
@@ -9,9 +9,7 @@ import { buildBaseUploadHostUrl } from "../utilities/buildBaseUploadHostUrl";
 
 export class Store implements StoreInterface {
   put(targetPath: string, _content: Content): Promise<URL> {
-    return Promise.resolve(
-      new URL(`${buildBaseUploadHostUrl()}/${targetPath}`)
-    );
+    return Promise.resolve(buildBaseUploadHostUrl(targetPath));
   }
 
   async putStream(
@@ -20,7 +18,7 @@ export class Store implements StoreInterface {
   ): Promise<URL> {
     const ws = new ServerWriteStream(targetPath);
     await doWriteToStream(ws);
-    return new URL(`${buildBaseUploadHostUrl()}/${targetPath}`);
+    return buildBaseUploadHostUrl(targetPath);
   }
 }
 
@@ -79,9 +77,9 @@ class ServerWriteStream implements WriteStream {
     }
 
     fetch(
-      `${buildBaseUploadHostUrl()}/upload?filename=${encodeURIComponent(
-        this.targetPath
-      )}`,
+      buildBaseUploadHostUrl(
+        `/upload?filename=${encodeURIComponent(this.targetPath)}`
+      ).toString(),
       {
         method: "POST",
         mode: "cors",

--- a/src/services/content.ts
+++ b/src/services/content.ts
@@ -87,7 +87,9 @@ export const sendPost = async (
 
 /**
  * sendReply stores a reply, creates an announcement for it, stores that in a batch, and publishes the batch.
- * @param post the post content to add
+ * @param fromId - Who is this from?
+ * @param reply - Content for the reply
+ * @param parentURI - What is it in reply to?
  * @returns a promise pending completion
  */
 export const sendReply = async (
@@ -108,7 +110,8 @@ export const sendReply = async (
 
 /**
  * sendProfile stores a profile, creates an announcement for it, stores that in a batch, and publishes the batch.
- * @param post the profile content to add
+ * @param fromId - Who is it from?
+ * @param profile - What is the profile
  * @returns a promise pending completion
  */
 export const saveProfile = async (
@@ -231,7 +234,6 @@ export const ProfileQuery = (
 /**
  * handleRegistryUpdate dispatches a profile update for the handle when a registry update is made.
  * @param dispatch function used to dispatch to store
- * @param update registry log message containg DSNP uri and handle
  */
 const handleRegistryUpdate = (dispatch: Dispatch) => (
   update: RegistryUpdateLogData
@@ -251,10 +253,9 @@ const handleRegistryUpdate = (dispatch: Dispatch) => (
 };
 
 /**
- * handleBatchAnnouncment retrieves and parses a batch and then routes its contents
+ * handleBatchAnnouncement retrieves and parses a batch and then routes its contents
  * to the redux store.
  * @param dispatch function used to dispatch to the store
- * @param batchAnnouncement announcement of batch (publication) to handle
  */
 const handleBatchAnnouncement = (dispatch: Dispatch) => (
   batchAnnouncement: BatchPublicationLogData

--- a/src/services/content.ts
+++ b/src/services/content.ts
@@ -31,6 +31,7 @@ import { DSNPAnnouncementURI, DSNPUserId } from "@dsnp/sdk/core/identifiers";
 import { FeedItem, User } from "../utilities/types";
 import { useQuery, UseQueryResult } from "react-query";
 import { Permission } from "@dsnp/sdk/core/contracts/identity";
+import { buildBaseUploadHostUrl } from "../utilities/buildBaseUploadHostUrl";
 
 //
 // Content Package
@@ -78,7 +79,7 @@ export const sendPost = async (
   const hash = await storeActivityContent(post);
   const announcement = await dsnp.buildAndSignPostAnnouncement(
     fromId,
-    `${process.env.REACT_APP_UPLOAD_HOST}/${hash}.json`,
+    buildBaseUploadHostUrl(`${hash}.json`).toString(),
     hash
   );
 
@@ -101,7 +102,7 @@ export const sendReply = async (
   const announcement = await dsnp.buildAndSignReplyAnnouncement(
     fromId,
     parentURI,
-    `${process.env.REACT_APP_UPLOAD_HOST}/${hash}.json`,
+    buildBaseUploadHostUrl(`${hash}.json`).toString(),
     hash
   );
 
@@ -121,7 +122,7 @@ export const saveProfile = async (
   const hash = await storeActivityContent(profile);
   const announcement = await dsnp.buildAndSignProfile(
     fromId,
-    `${process.env.REACT_APP_UPLOAD_HOST}/${hash}.json`,
+    buildBaseUploadHostUrl(`${hash}.json`).toString(),
     hash
   );
 
@@ -349,9 +350,9 @@ const storeActivityContent = async (
 ): Promise<string> => {
   const hash = keccak256(JSON.stringify(content));
   await fetch(
-    `${process.env.REACT_APP_UPLOAD_HOST}/upload?filename=${encodeURIComponent(
-      hash + ".json"
-    )}`,
+    buildBaseUploadHostUrl(
+      `/upload?filename=${encodeURIComponent(hash + ".json")}`
+    ).toString(),
     {
       method: "POST",
       mode: "cors",

--- a/src/utilities/buildBaseUploadHostUrl.test.ts
+++ b/src/utilities/buildBaseUploadHostUrl.test.ts
@@ -10,7 +10,7 @@ describe("buildBaseUploadHostUrl", () => {
   });
 
   afterEach(() => {
-    windowSpy.mockRestore();
+    windowSpy.mockClear();
   });
 
   afterAll(() => {
@@ -28,14 +28,43 @@ describe("buildBaseUploadHostUrl", () => {
       },
     }));
 
-    it("returns a qualified url for REACT_APP_UPLOAD_HOST", () => {
-      process.env.REACT_APP_UPLOAD_HOST = "";
-      expect(buildBaseUploadHostUrl()).toEqual("http://example.com");
+    it("doesn't do a double / prefix for the path", () => {
+      process.env.REACT_APP_UPLOAD_HOST = "http://test.com/";
+      expect(buildBaseUploadHostUrl("/path").toString()).toEqual(
+        "http://test.com/path"
+      );
     });
 
-    it("does not return a qualified url for REACT_APP_UPLOAD_HOST", () => {
-      process.env.REACT_APP_UPLOAD_HOST = "http://localhost:3000";
-      expect(buildBaseUploadHostUrl()).toEqual("http://localhost:3000");
+    describe("when REACT_APP_UPLOAD_HOST is empty", () => {
+      it("returns a qualified url", () => {
+        process.env.REACT_APP_UPLOAD_HOST = "";
+        expect(buildBaseUploadHostUrl("").toString()).toEqual(
+          "http://example.com/"
+        );
+      });
+
+      it("returns with the correct path", () => {
+        process.env.REACT_APP_UPLOAD_HOST = "";
+        expect(
+          buildBaseUploadHostUrl("/i-am-a/path/yes/i/am").toString()
+        ).toEqual("http://example.com/i-am-a/path/yes/i/am");
+      });
+    });
+
+    describe("when REACT_APP_UPLOAD_HOST is NOT empty", () => {
+      it("does not return a qualified url for REACT_APP_UPLOAD_HOST", () => {
+        process.env.REACT_APP_UPLOAD_HOST = "http://localhost:3000";
+        expect(buildBaseUploadHostUrl("").toString()).toEqual(
+          "http://localhost:3000/"
+        );
+      });
+
+      it("returns with the correct path", () => {
+        process.env.REACT_APP_UPLOAD_HOST = "http://localhost:3000";
+        expect(
+          buildBaseUploadHostUrl("/i-am-a/path/yes/i/am").toString()
+        ).toEqual("http://localhost:3000/i-am-a/path/yes/i/am");
+      });
     });
   });
 });

--- a/src/utilities/buildBaseUploadHostUrl.ts
+++ b/src/utilities/buildBaseUploadHostUrl.ts
@@ -1,6 +1,13 @@
-export const buildBaseUploadHostUrl = (): string => {
-  return (
-    process.env.REACT_APP_UPLOAD_HOST ||
-    `${window.location.protocol}//${window.location.host}`
-  );
+/**
+ * buildBaseUploadHostUrl returns the REACT_APP_UPLOAD_HOST
+ * or the current browser base url for if the server hosting the content
+ * is accessible using the same url
+ * @param path - The path to append to the url
+ * @returns the fully qualified URL
+ */
+export const buildBaseUploadHostUrl = (path: string): URL => {
+  if (process.env.REACT_APP_UPLOAD_HOST) {
+    return new URL(path, process.env.REACT_APP_UPLOAD_HOST);
+  }
+  return new URL(path, `${window.location.protocol}//${window.location.host}`);
 };


### PR DESCRIPTION
Purpose
---------------
Some generated urls were not using the correct 
[PT #179612435](https://www.pivotaltracker.com/story/show/179612435)


Solution
---------------
Use `buildBaseUploadHostUrl` everywhere instead of `REACT_APP_UPLOAD_HOST` directly

With @claireolmstead 

Change summary
---------------
* Update some invalid function docs
* buildBaseUploadHostUrl supports building the entire URL

Steps to Verify
----------------
1. Build a docker
2. See that it creates parquet files that have fully qualified urls

<img width="490" alt="image" src="https://user-images.githubusercontent.com/1252199/133677127-bb38ab14-3635-42fb-84ec-91c328c68d2a.png">
