### PR TITLE
Use the new v3.0.3 "dsnp-start-block"

### DIFF
--- a/src/services/dsnp.ts
+++ b/src/services/dsnp.ts
@@ -157,7 +157,7 @@ export const startSubscriptions = async (
     (announcement: BatchPublicationLogData) => {
       batchHandler(announcement);
     },
-    { fromBlock: 1 }
+    { fromBlock: "dsnp-start-block" }
   );
 
   // subscribe to registry events
@@ -165,7 +165,7 @@ export const startSubscriptions = async (
     (announcement: RegistryUpdateLogData) => {
       registryHandler(announcement);
     },
-    { fromBlock: 1 }
+    { fromBlock: "dsnp-start-block" }
   );
 
   return () => {


### PR DESCRIPTION
Purpose
---------------
Speed up the loading of subscriptions on non-dsnp only testnets (like Rinkeby).


Solution
---------------
SDK v3.0.3 added the ability to start at the "dsnp-start-block" instead of just starting at the chain genesis block, so use that to start subscriptions from instead of block `1`

Change summary
---------------
* Switch subscription fromBlock to "dsnp-start-block"


Steps to Verify
----------------
1. Open the inspector for MetaMask
2. Set MetaMask to Rinkeby
3. Set the EC wallet type to MetaMask
4. See that the network request from MetaMask starts with something greater than "0x1"

Old (Registry):
<img width="469" alt="image" src="https://user-images.githubusercontent.com/1252199/134007334-f3e78514-f57d-4b12-a05b-b7fd6e70f8bf.png">

New (Registry):
<img width="447" alt="image" src="https://user-images.githubusercontent.com/1252199/134007683-22ab5a2f-36a6-4c89-bea4-65dcd9a097a0.png">

New for Publications:
<img width="444" alt="image" src="https://user-images.githubusercontent.com/1252199/134007614-fa401f76-9fa8-4681-b710-71b6f66c2129.png">
