### PR TITLE
fix timestamp bug, misc styling, don't show choose registration unles…

### DIFF
--- a/src/components/EditRegistrationAccordion.tsx
+++ b/src/components/EditRegistrationAccordion.tsx
@@ -47,7 +47,7 @@ const EditRegistrationAccordion = ({
           onIdResolved={onIdResolved}
         />
       </Panel>
-      {registrations && registrations.length > 0 && (
+      {registrations && registrations.length > 1 && (
         <Panel
           header={
             <p className="EditRegistrationAccordion__panelTitle">

--- a/src/components/Profile.tsx
+++ b/src/components/Profile.tsx
@@ -105,7 +105,7 @@ const Profile = (): JSX.Element => {
               userId={userId}
               user={user}
               following={followedByCurrentuser}
-            ></GraphChangeButton>
+            />
           )}
         </div>
         <div className="ProfileBlock__personalInfo">
@@ -116,21 +116,14 @@ const Profile = (): JSX.Element => {
             onChange={(e) => setNewName(e.target.value)}
             disabled={!isEditing}
           />
-          <label className="ProfileBlock__personalInfoLabel">HANDLE</label>
-          <input
-            className="ProfileBlock__handle"
-            value={newHandle || newHandle === "" ? newHandle : handle}
-            onChange={(e) => setNewHandle(e.target.value)}
-            disabled={true}
-          />
-          <label className="ProfileBlock__personalInfoLabel">
-            SOCIAL ADDRESS
-          </label>
-          <input
-            className="ProfileBlock__dsnpUserId"
-            value={displayId || "Anonymous"}
-            disabled={true}
-          />
+
+          <div className="ProfileBlock__personalInfoLabel">HANDLE</div>
+          <div className="ProfileBlock__handle">@{handle}</div>
+
+          <div className="ProfileBlock__personalInfoLabel">SOCIAL ADDRESS</div>
+          <div className="ProfileBlock__dsnpUserId">
+            {displayId || "Anonymous"}
+          </div>
         </div>
       </div>
       <ConnectionsList />

--- a/src/components/RelativeTime.tsx
+++ b/src/components/RelativeTime.tsx
@@ -1,7 +1,6 @@
 import React from "react";
 
 const getMonthName = (monthNum: number) => {
-  monthNum--;
   const months = [
     "Jan",
     "Feb",
@@ -24,18 +23,18 @@ const getRelativeTime = (postTime: string) => {
   const currentTime = new Date();
   const secondsPast = (currentTime.getTime() - timeOfPost.getTime()) / 1000;
   if (secondsPast < 60) {
-    return Math.floor(secondsPast) + "s •";
+    return Math.floor(secondsPast) + "s";
   }
   if (secondsPast < 3600) {
-    return Math.floor(secondsPast / 60) + "m •";
+    return Math.floor(secondsPast / 60) + "m";
   }
   if (secondsPast <= 86400) {
-    return Math.floor(secondsPast / 3600) + "h •";
+    return Math.floor(secondsPast / 3600) + "h";
   }
   if (secondsPast > 86400) {
     return `${getMonthName(
       timeOfPost.getMonth()
-    )} ${timeOfPost.getDate()}, ${timeOfPost.getFullYear()} •`;
+    )} ${timeOfPost.getDate()}, ${timeOfPost.getFullYear()}`;
   }
 };
 

--- a/src/components/UserAvatar.tsx
+++ b/src/components/UserAvatar.tsx
@@ -7,7 +7,7 @@ import { userIdentification } from "../services/utilities";
 import { UserOutlined } from "@ant-design/icons";
 
 const avatarSizeOptions = new Map([
-  ["small", 32],
+  ["small", 28],
   ["medium", 50],
   ["large", 100],
 ]);

--- a/src/components/scss/Login.scss
+++ b/src/components/scss/Login.scss
@@ -25,6 +25,6 @@
 
 .Login__userTitle {
   font-size: 16px;
-  padding-left: 12px;
+  padding-left: 8px;
   font-weight: bold;
 }

--- a/src/components/scss/RelativeTime.scss
+++ b/src/components/scss/RelativeTime.scss
@@ -1,7 +1,9 @@
 .RelativeTime {
   margin: 0;
+  font-size: 13px;
 }
 
 .RelativeTime--post {
   font-weight: 500;
+  align-items: flex-end;
 }

--- a/src/components/test/ProfileBlock.test.tsx
+++ b/src/components/test/ProfileBlock.test.tsx
@@ -109,7 +109,7 @@ describe("Profile Block", () => {
 
     it("displays correct userId", async () => {
       const component = mount(componentWithStore(ProfileBlock, otherUserStore));
-      expect(component.find(".ProfileBlock__dsnpUserId").props().value).toEqual(
+      expect(component.find(".ProfileBlock__dsnpUserId").text()).toEqual(
         displayId
       );
     });

--- a/src/components/test/__snapshots__/RelativeTime.test.tsx.snap
+++ b/src/components/test/__snapshots__/RelativeTime.test.tsx.snap
@@ -4,7 +4,7 @@ exports[`relative time renders hours as expected 1`] = `
 <p
   className="RelativeTime RelativeTime--post"
 >
-  2h •
+  2h
 </p>
 `;
 
@@ -12,7 +12,7 @@ exports[`relative time renders minutes as expected 1`] = `
 <p
   className="RelativeTime RelativeTime--post"
 >
-  1m •
+  1m
 </p>
 `;
 
@@ -20,7 +20,7 @@ exports[`relative time renders seconds as expected 1`] = `
 <p
   className="RelativeTime RelativeTime--post"
 >
-  10s •
+  10s
 </p>
 `;
 
@@ -28,6 +28,6 @@ exports[`relative time renders years as expected 1`] = `
 <p
   className="RelativeTime RelativeTime--post"
 >
-  Nov 18, 2018 •
+  Dec 18, 2018
 </p>
 `;


### PR DESCRIPTION
Purpose
---------------
[https://www.pivotaltracker.com/story/show/179649749](url)
Feature


Solution
---------------
- should not show switch registrations unless there are 2+
- don't render handle and social address in the input blocks anymore since they are not inputs
- remove decrement in the monthNum of relative time
- remove the dots at the end of the date
- make small user avatar smaller


Change summary
---------------
* look to solution description


Steps to Verify
----------------
1. run code
2. makes sure it looks good and doesn't throw errors


Additional details / screenshot
----------------
- Any supplemental pictures or material
- ![Screenshot]()
