### PR TITLE
registration modal cancel button bug squashed

### DIFF
--- a/src/components/RegistrationModal.tsx
+++ b/src/components/RegistrationModal.tsx
@@ -22,6 +22,7 @@ const RegistrationModal = ({
   onIdResolved,
   logout,
 }: RegistrationModalProps): JSX.Element => {
+  const userId = useAppSelector((state) => state.user.id);
   const registrations = useAppSelector((state) => state.user.registrations);
   const [hasRegistrations, setHasRegistrations] = React.useState<boolean>(
     false
@@ -46,6 +47,13 @@ const RegistrationModal = ({
     }
   }
 
+  const handleVisibleChange = () => {
+    if (!userId) {
+      logout();
+    }
+    setRegistrationVisible(!visible);
+  };
+
   /**
    * Create a popover with either registration or handle selection UI.
    */
@@ -54,7 +62,7 @@ const RegistrationModal = ({
       placement="bottomRight"
       visible={visible}
       trigger="click"
-      onVisibleChange={() => setRegistrationVisible(!visible)}
+      onVisibleChange={handleVisibleChange}
       content={
         <EditRegistration
           logout={logout}


### PR DESCRIPTION
Purpose
---------------
bug
[https://www.pivotaltracker.com/story/show/179627278](url)
if you are not yet logged into a userId and click out of the registration modal, you should be logged out, or else you are stuck in the loading state.


to recreate bug
----------------
- in main, select a metamask account with no handle created or with multiple handles created
- click log in
- click metamask
- see registration modal
- click outside of the modal and see it close
- see the spinner in the log in button and that you are unable to click the log in button now


Change summary
---------------
- add a function that is called on onVisibleChange
- if there is no userID, logout
- always set the registration visible variable as the opposite of whatever the current value is.


Steps to Verify
----------------
1. follow the steps above to recreate the bug
2. go to this branch
3. check that that the bug doesn't reoccur


Additional details / screenshot
----------------
- Any supplemental pictures or material
- ![Screenshot]()
