### PR TITLE
edit profile picture modal

### DIFF
--- a/src/App.scss
+++ b/src/App.scss
@@ -28,6 +28,7 @@
 @import "components/scss/BlankReply";
 @import "components/scss/EditRegistrationAccordion";
 @import "components/scss/EditRegistration";
+@import "components/scss/EditAvatarModal";
 
 .App__content {
   display: flex;

--- a/src/components/EditAvatarModal.tsx
+++ b/src/components/EditAvatarModal.tsx
@@ -1,0 +1,95 @@
+import React from "react";
+import UserAvatar from "./UserAvatar";
+import { useAppDispatch, useAppSelector } from "../redux/hooks";
+import * as types from "../utilities/types";
+import { Alert, Button, Input, Modal } from "antd";
+import { useState } from "react";
+import { CameraOutlined } from "@ant-design/icons";
+import { ActivityContentImageLink } from "@dsnp/sdk/core/activityContent";
+import { core } from "@dsnp/sdk";
+import path from "path";
+import { setTempIconUri } from "../redux/slices/userSlice";
+
+interface EditAvatarModalProps {
+  setNewIcon: (icon: ActivityContentImageLink[] | undefined) => void;
+}
+
+const EditAvatarModal = ({ setNewIcon }: EditAvatarModalProps): JSX.Element => {
+  const dispatch = useAppDispatch();
+
+  const userId: string | undefined = useAppSelector((state) => state.user.id);
+  const profiles: Record<types.HexString, types.User> = useAppSelector(
+    (state) => state.profiles?.profiles || {}
+  );
+  const user: types.User | undefined = userId ? profiles[userId] : undefined;
+
+  const [isModalVisible, setIsModalVisible] = useState<boolean>(false);
+  const [iconUri, setIconUri] = React.useState<string>("");
+  const [urlErrorMsg, setUrlErrorMsg] = React.useState<string | null>(null);
+  const hasValidPostURI = iconUri && String(iconUri).match(/.+\..+\//);
+
+  const handleNewUri = () => {
+    if (hasValidPostURI) {
+      const extension = path.extname(iconUri).replace(".", "");
+      const imageLink = core.activityContent.createImageLink(
+        iconUri,
+        `image/${extension}`,
+        [core.activityContent.createHash(iconUri)]
+      );
+      dispatch(setTempIconUri(imageLink.href));
+      setIsModalVisible(false);
+      setNewIcon([imageLink]);
+      setIconUri("");
+    } else {
+      setUrlErrorMsg("Invalid URL.");
+    }
+  };
+
+  const handleCancel = () => {
+    setIsModalVisible(false);
+    setIconUri("");
+    dispatch(setTempIconUri(undefined));
+  };
+
+  return (
+    <>
+      <div
+        onClick={() => setIsModalVisible(true)}
+        className="EditAvatarModal__button"
+      >
+        <UserAvatar user={user} avatarSize="large" />
+        <div className="EditAvatarModal__edit">edit</div>
+      </div>
+      <Modal visible={isModalVisible} onCancel={handleCancel} footer={null}>
+        <div className="EditAvatarModal__avatarPreview">
+          <UserAvatar user={user} avatarSize="xl" />
+        </div>
+        <div className="NewPostImageUpload__urlInputBlock">
+          <CameraOutlined style={{ fontSize: "28px" }} />
+          <Input
+            className="NewPostImageUpload__urlInput"
+            placeholder="Content URL"
+            value={iconUri || ""}
+            onChange={(e) => setIconUri(e.target.value)}
+            onPressEnter={handleNewUri}
+          />
+          <Button
+            className="NewPostImageUpload__urlInputBtn"
+            onClick={handleNewUri}
+          >
+            Add
+          </Button>
+        </div>
+        {urlErrorMsg && (
+          <Alert
+            className="NewPostImageUpload__alert"
+            type="error"
+            message={urlErrorMsg}
+          />
+        )}
+      </Modal>
+    </>
+  );
+};
+
+export default EditAvatarModal;

--- a/src/components/Profile.tsx
+++ b/src/components/Profile.tsx
@@ -52,7 +52,7 @@ const Profile = (): JSX.Element => {
       return;
     }
     setDidEditProfile(false);
-  }, [newName, newIcon, profileName, handle]);
+  }, [newName, newIcon, profile?.icon, profileName, handle]);
   const [isEditing, setIsEditing] = useState<boolean>(false);
 
   const getClassName = (sectionName: string) => {

--- a/src/components/UserAvatar.tsx
+++ b/src/components/UserAvatar.tsx
@@ -5,11 +5,13 @@ import { User } from "../utilities/types";
 import { ProfileQuery } from "../services/content";
 import { userIdentification } from "../services/utilities";
 import { UserOutlined } from "@ant-design/icons";
+import { useAppSelector } from "../redux/hooks";
 
 const avatarSizeOptions = new Map([
   ["small", 28],
   ["medium", 50],
   ["large", 100],
+  ["xl", 150],
 ]);
 
 interface UserAvatarProps {
@@ -19,6 +21,10 @@ interface UserAvatarProps {
 
 const UserAvatar = ({ user, avatarSize }: UserAvatarProps): JSX.Element => {
   const { data: profile } = ProfileQuery(user);
+
+  const tempIconUri: string | undefined = useAppSelector(
+    (state) => state.user.tempIconUri
+  );
 
   const iconURL =
     user === undefined
@@ -33,7 +39,7 @@ const UserAvatar = ({ user, avatarSize }: UserAvatarProps): JSX.Element => {
       className="UserAvatar"
       alt={name}
       icon={<UserOutlined />}
-      src={iconURL}
+      src={tempIconUri ? tempIconUri : iconURL}
       size={avatarSizeOptions.get(avatarSize)}
       style={{ minWidth: avatarSizeOptions.get(avatarSize) }}
     />

--- a/src/components/scss/EditAvatarModal.scss
+++ b/src/components/scss/EditAvatarModal.scss
@@ -1,0 +1,17 @@
+.EditAvatarModal__button {
+  position: relative;
+  cursor: pointer;
+}
+
+.EditAvatarModal__edit {
+  position: absolute;
+  bottom: 8px;
+  left: 35px;
+  color: $white;
+  text-transform: uppercase;
+  text-shadow: 3px 3px 5px $black;
+}
+
+.EditAvatarModal__avatarPreview {
+  text-align: center;
+}

--- a/src/components/test/EditAvatarModal.test.tsx
+++ b/src/components/test/EditAvatarModal.test.tsx
@@ -1,0 +1,51 @@
+import React from "react";
+import { mount, shallow } from "enzyme";
+import { componentWithStore, createMockStore } from "../../test/testhelpers";
+import { getPrefabProfile } from "../../test/testProfiles";
+import EditAvatarModal from "../EditAvatarModal";
+
+const userProfile = getPrefabProfile(0);
+const displayProfile = getPrefabProfile(3);
+const initialState = {
+  user: {
+    id: userProfile.fromId,
+    displayId: displayProfile.fromId as string | undefined,
+  },
+  profiles: {
+    profiles: {
+      [userProfile.fromId]: userProfile,
+      [displayProfile.fromId]: displayProfile,
+    },
+  },
+};
+const store = createMockStore(initialState);
+
+describe("EditAvatarModal", () => {
+  it("renders without crashing", () => {
+    expect(() => {
+      shallow(
+        componentWithStore(
+          () => <EditAvatarModal setNewIcon={jest.fn} />,
+          createMockStore(store)
+        )
+      );
+    }).not.toThrow();
+  });
+
+  it("adds photo", async () => {
+    const component = mount(
+      componentWithStore(EditAvatarModal, store, { setNewIcon: jest.fn() })
+    );
+    component.find(".EditAvatarModal__edit").simulate("click");
+    component.find("input").simulate("change", {
+      target: { value: "https://placekitten.com/300/300" },
+    });
+    component
+      .find(".NewPostImageUpload__urlInputBtn")
+      .first()
+      .simulate("click");
+    expect(component.find("input").props().value).toEqual(
+      "https://placekitten.com/300/300"
+    );
+  });
+});

--- a/src/redux/slices/userSlice.ts
+++ b/src/redux/slices/userSlice.ts
@@ -8,6 +8,7 @@ interface UserState {
   walletType: wallet.WalletType;
   displayId?: string;
   registrations?: Registration[];
+  tempIconUri?: string;
 }
 
 const initialState: UserState = {
@@ -47,6 +48,10 @@ export const userSlice = createSlice({
       ...state,
       registrations: action.payload,
     }),
+    setTempIconUri: (state, action: PayloadAction<string | undefined>) => ({
+      ...state,
+      tempIconUri: action.payload,
+    }),
   },
 });
 export const {
@@ -56,5 +61,6 @@ export const {
   userUpdateWalletType,
   setDisplayId,
   setRegistrations,
+  setTempIconUri,
 } = userSlice.actions;
 export default userSlice.reducer;

--- a/src/utilities/activityContent.ts
+++ b/src/utilities/activityContent.ts
@@ -13,9 +13,7 @@ import {
   createNote,
 } from "@dsnp/sdk/core/activityContent";
 
-export const createMediaAttachment = (
-  item: string
-): ActivityContentAttachment => {
+const createMediaAttachment = (item: string): ActivityContentAttachment => {
   const extension = path.extname(item).replace(".", "");
 
   const host = new URL(item).host;

--- a/src/utilities/activityContent.ts
+++ b/src/utilities/activityContent.ts
@@ -13,7 +13,9 @@ import {
   createNote,
 } from "@dsnp/sdk/core/activityContent";
 
-const createMediaAttachment = (item: string): ActivityContentAttachment => {
+export const createMediaAttachment = (
+  item: string
+): ActivityContentAttachment => {
   const extension = path.extname(item).replace(".", "");
 
   const host = new URL(item).host;


### PR DESCRIPTION
Purpose
---------------
Feature
As a user, I should be able to edit my profile picture
[https://www.pivotaltracker.com/story/show/179324830](https://www.pivotaltracker.com/story/show/179324830)

Solution
---------------
- onClick of the edit button in the profile component you should be able to edit your profile picture with a new URL.

Change summary
---------------
* Create EditAvatarModal that gives the user a UI to upload their new profile photo and returns the ActivityContentImageLink value.
* if edited, save the new profile icon in the Profile component
* create temp icon uri state that displays that new icon until the real iconURL is completely loaded
* styling for the new UI
* test for the new UI
* if you cancel it clears inputs/states

Steps to Verify
----------------
1. click edit
2. click edit on profile photo
3. put in valid url
4. try invalid url
5. try add in both cases
6. try cancel from modal
7. try cancel after new image is uploaded
8. click save after new image is uploaded

Additional details / screenshot
---------------

https://user-images.githubusercontent.com/43625033/134262675-c6192cf0-9ba6-4b2f-82f3-f08d03c8e94f.mov
