### PR TITLE
Feature/profile preview in edit registration/179585383

### DIFF
--- a/src/App.scss
+++ b/src/App.scss
@@ -29,6 +29,7 @@
 @import "components/scss/EditRegistrationAccordion";
 @import "components/scss/EditRegistration";
 @import "components/scss/EditAvatarModal";
+@import "components/scss/RegistrationPreview";
 
 .App__content {
   display: flex;

--- a/src/components/CreateRegistration.tsx
+++ b/src/components/CreateRegistration.tsx
@@ -12,13 +12,13 @@ import { Registration } from "@dsnp/sdk/core/contracts/registry";
 interface CreateRegistrationProps {
   walletAddress: HexString;
   onIdResolved: (uri: DSNPUserURI) => void;
-  setUserPreview: (registration: Registration | undefined) => void;
+  setRegistrationPreview: (registration: Registration | undefined) => void;
 }
 
 const CreateRegistration = ({
   walletAddress,
   onIdResolved,
-  setUserPreview,
+  setRegistrationPreview,
 }: CreateRegistrationProps): JSX.Element => {
   const dispatch = useAppDispatch();
   const [registrationError, setRegistrationError] = React.useState<
@@ -29,7 +29,7 @@ const CreateRegistration = ({
 
   // create new DSNP registration
   const register = async (formValues: { handle: string }) => {
-    setUserPreview(undefined);
+    setRegistrationPreview(undefined);
     form.resetFields();
     try {
       const userURI = await dsnp.createNewDSNPRegistration(

--- a/src/components/CreateRegistration.tsx
+++ b/src/components/CreateRegistration.tsx
@@ -1,5 +1,5 @@
 import { Alert, Button, Form, Input } from "antd";
-import React from "react";
+import React, { useRef } from "react";
 import * as dsnp from "../services/dsnp";
 import { core } from "@dsnp/sdk";
 import { HexString } from "../utilities/types";
@@ -7,23 +7,30 @@ import { DSNPUserURI } from "@dsnp/sdk/core/identifiers";
 import { setRegistrations } from "../redux/slices/userSlice";
 import { useAppDispatch } from "../redux/hooks";
 import { friendlyError } from "../services/errors";
+import { Registration } from "@dsnp/sdk/core/contracts/registry";
 
 interface CreateRegistrationProps {
   walletAddress: HexString;
   onIdResolved: (uri: DSNPUserURI) => void;
+  setUserPreview: (registration: Registration | undefined) => void;
 }
 
 const CreateRegistration = ({
   walletAddress,
   onIdResolved,
+  setUserPreview,
 }: CreateRegistrationProps): JSX.Element => {
   const dispatch = useAppDispatch();
   const [registrationError, setRegistrationError] = React.useState<
     string | undefined
   >(undefined);
 
+  const [form] = Form.useForm();
+
   // create new DSNP registration
   const register = async (formValues: { handle: string }) => {
+    setUserPreview(undefined);
+    form.resetFields();
     try {
       const userURI = await dsnp.createNewDSNPRegistration(
         walletAddress,
@@ -40,6 +47,7 @@ const CreateRegistration = ({
 
   return (
     <Form
+      form={form}
       name="createHandle"
       className="RegistrationModal__createHandle"
       initialValues={{
@@ -70,7 +78,7 @@ const CreateRegistration = ({
           htmlType="submit"
           className="RegistrationModal__footerBtn"
         >
-          Choose handle
+          Create Handle
         </Button>
       </div>
     </Form>

--- a/src/components/CreateRegistration.tsx
+++ b/src/components/CreateRegistration.tsx
@@ -1,5 +1,5 @@
 import { Alert, Button, Form, Input } from "antd";
-import React, { useRef } from "react";
+import React from "react";
 import * as dsnp from "../services/dsnp";
 import { core } from "@dsnp/sdk";
 import { HexString } from "../utilities/types";

--- a/src/components/EditRegistration.tsx
+++ b/src/components/EditRegistration.tsx
@@ -1,9 +1,11 @@
 import { Button } from "antd";
 import EditRegistrationAccordion from "./EditRegistrationAccordion";
-import React from "react";
+import React, { useState } from "react";
 import { HexString } from "../utilities/types";
 import { DSNPUserURI } from "@dsnp/sdk/core/identifiers";
 import { useAppSelector } from "../redux/hooks";
+import RegistrationPreview from "./RegistrationPreview";
+import { Registration } from "@dsnp/sdk/core/contracts/registry";
 
 interface EditRegistrationProps {
   logout: () => void;
@@ -19,6 +21,7 @@ const EditRegistration = ({
   onIdResolved,
 }: EditRegistrationProps): JSX.Element => {
   const userId = useAppSelector((state) => state.user.id);
+  const [currentUser, setUserPreview] = useState<Registration | undefined>();
 
   return (
     <div className="EditRegistration">
@@ -38,10 +41,12 @@ const EditRegistration = ({
       ) : (
         <p className="EditRegistration__title">Edit</p>
       )}
+      <RegistrationPreview currentRegistration={currentUser} />
       <EditRegistrationAccordion
         isCreatingRegistration={isCreatingRegistration}
         walletAddress={walletAddress}
         onIdResolved={onIdResolved}
+        setUserPreview={setUserPreview}
       />
       <Button
         className="EditRegistration__logoutButton"

--- a/src/components/EditRegistration.tsx
+++ b/src/components/EditRegistration.tsx
@@ -21,7 +21,9 @@ const EditRegistration = ({
   onIdResolved,
 }: EditRegistrationProps): JSX.Element => {
   const userId = useAppSelector((state) => state.user.id);
-  const [currentUser, setUserPreview] = useState<Registration | undefined>();
+  const [registrationPreview, setRegistrationPreview] = useState<
+    Registration | undefined
+  >();
 
   return (
     <div className="EditRegistration">
@@ -41,12 +43,12 @@ const EditRegistration = ({
       ) : (
         <p className="EditRegistration__title">Edit</p>
       )}
-      <RegistrationPreview currentRegistration={currentUser} />
+      <RegistrationPreview registrationPreview={registrationPreview} />
       <EditRegistrationAccordion
         isCreatingRegistration={isCreatingRegistration}
         walletAddress={walletAddress}
         onIdResolved={onIdResolved}
-        setUserPreview={setUserPreview}
+        setRegistrationPreview={setRegistrationPreview}
       />
       <Button
         className="EditRegistration__logoutButton"

--- a/src/components/EditRegistrationAccordion.tsx
+++ b/src/components/EditRegistrationAccordion.tsx
@@ -12,14 +12,14 @@ interface EditRegistrationAccordionProps {
   isCreatingRegistration: boolean;
   walletAddress: HexString;
   onIdResolved: (uri: DSNPUserURI) => void;
-  setUserPreview: (user: Registration | undefined) => void;
+  setRegistrationPreview: (user: Registration | undefined) => void;
 }
 
 const EditRegistrationAccordion = ({
   isCreatingRegistration,
   walletAddress,
   onIdResolved,
-  setUserPreview,
+  setRegistrationPreview,
 }: EditRegistrationAccordionProps): JSX.Element => {
   const userId = useAppSelector((state) => state.user.id);
   const registrations = useAppSelector((state) => state.user.registrations);
@@ -48,7 +48,7 @@ const EditRegistrationAccordion = ({
         <CreateRegistration
           walletAddress={walletAddress}
           onIdResolved={onIdResolved}
-          setUserPreview={setUserPreview}
+          setRegistrationPreview={setRegistrationPreview}
         />
       </Panel>
       {registrations && registrations.length > 1 && (
@@ -63,7 +63,7 @@ const EditRegistrationAccordion = ({
           <SelectHandle
             onIdResolved={onIdResolved}
             registrations={registrations}
-            setUserPreview={setUserPreview}
+            setRegistrationPreview={setRegistrationPreview}
           />
         </Panel>
       )}

--- a/src/components/EditRegistrationAccordion.tsx
+++ b/src/components/EditRegistrationAccordion.tsx
@@ -5,18 +5,21 @@ import SelectHandle from "./SelectHandle";
 import { HexString } from "../utilities/types";
 import { DSNPUserURI } from "@dsnp/sdk/core/identifiers";
 import { useAppSelector } from "../redux/hooks";
+import { Registration } from "@dsnp/sdk/core/contracts/registry";
 const { Panel } = Collapse;
 
 interface EditRegistrationAccordionProps {
   isCreatingRegistration: boolean;
   walletAddress: HexString;
   onIdResolved: (uri: DSNPUserURI) => void;
+  setUserPreview: (user: Registration | undefined) => void;
 }
 
 const EditRegistrationAccordion = ({
   isCreatingRegistration,
   walletAddress,
   onIdResolved,
+  setUserPreview,
 }: EditRegistrationAccordionProps): JSX.Element => {
   const userId = useAppSelector((state) => state.user.id);
   const registrations = useAppSelector((state) => state.user.registrations);
@@ -45,6 +48,7 @@ const EditRegistrationAccordion = ({
         <CreateRegistration
           walletAddress={walletAddress}
           onIdResolved={onIdResolved}
+          setUserPreview={setUserPreview}
         />
       </Panel>
       {registrations && registrations.length > 1 && (
@@ -59,6 +63,7 @@ const EditRegistrationAccordion = ({
           <SelectHandle
             onIdResolved={onIdResolved}
             registrations={registrations}
+            setUserPreview={setUserPreview}
           />
         </Panel>
       )}

--- a/src/components/RegistrationPreview.tsx
+++ b/src/components/RegistrationPreview.tsx
@@ -6,14 +6,14 @@ import { Registration } from "@dsnp/sdk/core/contracts/registry";
 import { convertToDSNPUserId } from "@dsnp/sdk/core/identifiers";
 
 interface RegistrationPreviewProps {
-  currentRegistration: Registration | undefined;
+  registrationPreview: Registration | undefined;
 }
 
 const RegistrationPreview = ({
-  currentRegistration,
+  registrationPreview,
 }: RegistrationPreviewProps): JSX.Element => {
-  const curId = currentRegistration
-    ? convertToDSNPUserId(currentRegistration.dsnpUserURI).toString()
+  const curId = registrationPreview
+    ? convertToDSNPUserId(registrationPreview.dsnpUserURI).toString()
     : undefined;
   const userId = useAppSelector((state) => state.user.id);
   const profiles: Record<types.HexString, types.User> = useAppSelector(

--- a/src/components/RegistrationPreview.tsx
+++ b/src/components/RegistrationPreview.tsx
@@ -1,0 +1,45 @@
+import React from "react";
+import UserAvatar from "./UserAvatar";
+import { useAppSelector } from "../redux/hooks";
+import * as types from "../utilities/types";
+import { Registration } from "@dsnp/sdk/core/contracts/registry";
+import { convertToDSNPUserId } from "@dsnp/sdk/core/identifiers";
+
+interface RegistrationPreviewProps {
+  currentRegistration: Registration | undefined;
+}
+
+const RegistrationPreview = ({
+  currentRegistration,
+}: RegistrationPreviewProps): JSX.Element => {
+  const curId = currentRegistration
+    ? convertToDSNPUserId(currentRegistration.dsnpUserURI).toString()
+    : undefined;
+  const userId = useAppSelector((state) => state.user.id);
+  const profiles: Record<types.HexString, types.User> = useAppSelector(
+    (state) => state.profiles?.profiles || {}
+  );
+  const user: types.User | undefined = curId
+    ? profiles[curId]
+    : userId
+    ? profiles[userId]
+    : undefined;
+
+  return (
+    <div className="RegistrationPreview__block">
+      <UserAvatar user={user} avatarSize={"medium"} />
+      <div
+        className={`RegistrationPreview__infoBlock ${
+          !user && "RegistrationPreview__infoBlock--unselected"
+        }`}
+      >
+        <div className="RegistrationPreview__handle">@{user?.handle}</div>
+        <div className="RegistrationPreview__id">
+          {user?.name || user?.fromId || "0000"}
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default RegistrationPreview;

--- a/src/components/SelectHandle.tsx
+++ b/src/components/SelectHandle.tsx
@@ -11,13 +11,13 @@ import { DSNPUserURI } from "@dsnp/sdk/core/identifiers";
 interface SelectHandleProps {
   onIdResolved: (uri: DSNPUserURI) => void;
   registrations: registry.Registration[];
-  setUserPreview: (user: registry.Registration | undefined) => void;
+  setRegistrationPreview: (user: registry.Registration | undefined) => void;
 }
 
 const SelectHandle = ({
   onIdResolved,
   registrations,
-  setUserPreview,
+  setRegistrationPreview,
 }: SelectHandleProps): JSX.Element => {
   const [selectedRegistration, setRegistration] = React.useState<
     registry.Registration | undefined
@@ -30,7 +30,7 @@ const SelectHandle = ({
   const commitRegistration = () => {
     if (!selectedRegistration) return;
     onIdResolved(selectedRegistration.dsnpUserURI);
-    setUserPreview(undefined);
+    setRegistrationPreview(undefined);
   };
 
   return (
@@ -47,7 +47,7 @@ const SelectHandle = ({
             }`}
             onClick={() => {
               setRegistration(registration);
-              setUserPreview(registration);
+              setRegistrationPreview(registration);
             }}
             key={registration.dsnpUserURI}
           >

--- a/src/components/SelectHandle.tsx
+++ b/src/components/SelectHandle.tsx
@@ -11,11 +11,13 @@ import { DSNPUserURI } from "@dsnp/sdk/core/identifiers";
 interface SelectHandleProps {
   onIdResolved: (uri: DSNPUserURI) => void;
   registrations: registry.Registration[];
+  setUserPreview: (user: registry.Registration | undefined) => void;
 }
 
 const SelectHandle = ({
   onIdResolved,
   registrations,
+  setUserPreview,
 }: SelectHandleProps): JSX.Element => {
   const [selectedRegistration, setRegistration] = React.useState<
     registry.Registration | undefined
@@ -28,6 +30,7 @@ const SelectHandle = ({
   const commitRegistration = () => {
     if (!selectedRegistration) return;
     onIdResolved(selectedRegistration.dsnpUserURI);
+    setUserPreview(undefined);
   };
 
   return (
@@ -42,7 +45,10 @@ const SelectHandle = ({
                 ? " RegistrationModal__registration--selected"
                 : ""
             }`}
-            onClick={() => setRegistration(registration)}
+            onClick={() => {
+              setRegistration(registration);
+              setUserPreview(registration);
+            }}
             key={registration.dsnpUserURI}
           >
             <UserAvatar

--- a/src/components/scss/RegistrationPreview.scss
+++ b/src/components/scss/RegistrationPreview.scss
@@ -1,0 +1,24 @@
+.RegistrationPreview__block {
+  display: flex;
+  padding: 4px 16px;
+}
+
+.RegistrationPreview__infoBlock {
+  display: flex;
+  flex-direction: column;
+  margin-left: 16px;
+}
+
+.RegistrationPreview__infoBlock--unselected {
+  color: $gray;
+}
+
+.RegistrationPreview__handle {
+  @include medium-text;
+
+  font-weight: bold;
+}
+
+.RegistrationPreview__id {
+  @include small-text;
+}


### PR DESCRIPTION
Purpose
---------------
Feature
[https://www.pivotaltracker.com/story/show/179585383](https://www.pivotaltracker.com/story/show/179585383)
As a user, I want to see a preview of my profile when selecting handles.

Solution
---------------
- Add profile preview in the editRegistration component
- style after the above wireframes in zeplin

Change summary
---------------
* created RegistrationPreview component
* styled accordingly
* passed the user info to preview into that component

Steps to Verify
----------------
1. try logging in and selecting a handle.
2. see your profile preview


Additional details / screenshot
---------------

https://user-images.githubusercontent.com/43625033/134993890-b9aa9fc0-2eff-4955-b54a-ed8059747937.mov

