### PR TITLE
add auto hyphenation for all browsers

### DIFF
--- a/src/components/scss/Post.scss
+++ b/src/components/scss/Post.scss
@@ -5,6 +5,11 @@
 
 .Post__caption {
   margin: 16px 0;
+  word-wrap: break-word;
+  overflow-wrap: break-word;
+  -webkit-hyphens: auto;
+  -moz-hyphens: auto;
+  hyphens: auto;
 }
 
 .Post__metaBlock {

--- a/src/components/scss/Reply.scss
+++ b/src/components/scss/Reply.scss
@@ -1,7 +1,6 @@
 .Reply__block {
   position: relative;
   margin-bottom: 14px;
-  max-height: 400px;
   flex-grow: 1;
   background-color: $light-gray;
   padding: 4px;
@@ -23,4 +22,9 @@
 
 .Reply__message {
   margin-left: 38px;
+  word-wrap: break-word;
+  overflow-wrap: break-word;
+  -webkit-hyphens: auto;
+  -moz-hyphens: auto;
+  hyphens: auto;
 }


### PR DESCRIPTION
Purpose
---------------
Bug
[https://www.pivotaltracker.com/story/show/179596345](https://www.pivotaltracker.com/story/show/179596345)
If there is a very long string, it was overflowing.  We want to hyphenate the string instead.


Solution
---------------
Hyphenate and word break in scss. Make compatible for all browsers.


Change summary
---------------
* Add hyphens and word break in scss
* Apply this same formatting to replies


Steps to Verify
----------------
1. type in a string like "hdhdhddhhdhdhdhdhdhdhhdhdhdbdbdbeuwywguwushsvsvdbjdjdbdbdbdbdbbddbbdbdbdbdbdbdbdbbdbdbbdbdheuwuuehehehehehehjejejejdjdjdhhdhdhdhdhdhdhhhdhdhdhdhdbdbhddhhdhdhhdhdhdhdhdhdhdhdhhdhdhdhdhdhhdhdhdhdhdhhdhdhdhdhhdhdhdhdhdhhdhdhdbdbbdbdbdbdbdbdbbdbdbdbwuueueyyeyeyehehehebdbdbbdbyxjdjfjcjcjvjcivivivivivivivivivicjcjvjcjcjvjvjvjvucicicjcjvivivicicicicicicicicicicicicicicicicicicicicicicucucucjcjcicicicicicicicicufufifdjdiruririridjfjfjfjfjfjdjdjdjdjdjdjdjdjxjxjcjxjcjcjckfkfjfjfjfifififkckckckckckfusyeueu" to new post.
2. try the same thing in reply.


Additional details / screenshot
---------------
![Screen Shot 2021-09-30 at 4 42 34 PM](https://user-images.githubusercontent.com/43625033/135544885-9fd9f084-7d9f-441d-8817-7542183c76b7.png)

