### PR TITLE
Bug/follow unfollow graph state update/179326255

### DIFF
--- a/src/components/ConnectionsList.tsx
+++ b/src/components/ConnectionsList.tsx
@@ -10,9 +10,9 @@ import { User } from "../utilities/types";
 import { AnnouncementType } from "@dsnp/sdk/core/announcements";
 
 enum ListStatus {
-  CLOSED,
-  FOLLOWERS,
-  FOLLOWING,
+  CLOSED = "CLOSED",
+  FOLLOWERS = "FOLLOWERS",
+  FOLLOWING = "FOLLOWING",
 }
 
 const ConnectionsList = (): JSX.Element => {

--- a/src/components/ConnectionsList.tsx
+++ b/src/components/ConnectionsList.tsx
@@ -37,6 +37,11 @@ const ConnectionsList = (): JSX.Element => {
       : "ConnectionsList__button";
   };
 
+  console.log("following user", Object.keys(followingDisplayUser).length);
+  console.log("followed by user", Object.keys(followedByDisplayUser).length);
+  console.log("following user", followingDisplayUser);
+  console.log("followed by user", followedByDisplayUser);
+
   return (
     <div className="ConnectionsList__block">
       <div className="ConnectionsList__buttonBlock">

--- a/src/components/ConnectionsList.tsx
+++ b/src/components/ConnectionsList.tsx
@@ -2,6 +2,12 @@ import React, { useState } from "react";
 import { Button } from "antd";
 import ConnectionsListProfiles from "./ConnectionsListProfiles";
 import { useAppSelector } from "../redux/hooks";
+import {
+  RelationshipState,
+  RelationshipStatus,
+} from "../redux/slices/graphSlice";
+import { User } from "../utilities/types";
+import { AnnouncementType } from "@dsnp/sdk/core/announcements";
 
 enum ListStatus {
   CLOSED,
@@ -23,6 +29,36 @@ const ConnectionsList = (): JSX.Element => {
     ListStatus.CLOSED
   );
 
+  const users: Record<string, User> = useAppSelector(
+    (state) => state.profiles?.profiles || {}
+  );
+
+  const profileForId = (userId: string): User =>
+    users[userId] || {
+      contentHash: "",
+      url: "",
+      announcementType: AnnouncementType.Profile,
+      fromId: userId,
+      handle: "unknown",
+    };
+
+  const connectionsList = (
+    relations: Record<string, RelationshipState>
+  ): User[] =>
+    Object.keys(relations)
+      .map(profileForId)
+      .filter(
+        (profile: User) =>
+          relations[profile.fromId]?.status !== RelationshipStatus.UNFOLLOWING
+      );
+
+  const relations =
+    selectedListTitle === ListStatus.FOLLOWERS
+      ? followingDisplayUser
+      : selectedListTitle === ListStatus.FOLLOWING
+      ? followedByDisplayUser
+      : {};
+
   const handleClick = (listTitle: ListStatus) => {
     if (selectedListTitle === listTitle)
       setSelectedListTitle(ListStatus.CLOSED);
@@ -37,11 +73,6 @@ const ConnectionsList = (): JSX.Element => {
       : "ConnectionsList__button";
   };
 
-  console.log("following user", Object.keys(followingDisplayUser).length);
-  console.log("followed by user", Object.keys(followedByDisplayUser).length);
-  console.log("following user", followingDisplayUser);
-  console.log("followed by user", followedByDisplayUser);
-
   return (
     <div className="ConnectionsList__block">
       <div className="ConnectionsList__buttonBlock">
@@ -50,7 +81,7 @@ const ConnectionsList = (): JSX.Element => {
           onClick={() => handleClick(ListStatus.FOLLOWERS)}
         >
           <div className="ConnectionsList__buttonCount">
-            {Object.keys(followingDisplayUser).length}
+            {connectionsList(followingDisplayUser).length}
           </div>
           Followers
         </Button>
@@ -59,7 +90,7 @@ const ConnectionsList = (): JSX.Element => {
           onClick={() => handleClick(ListStatus.FOLLOWING)}
         >
           <div className="ConnectionsList__buttonCount">
-            {Object.keys(followedByDisplayUser).length}
+            {connectionsList(followedByDisplayUser).length}
           </div>
           Following
         </Button>
@@ -67,9 +98,7 @@ const ConnectionsList = (): JSX.Element => {
       {userId && (
         <ConnectionsListProfiles
           userId={userId}
-          listStatus={selectedListTitle}
-          followedByDisplayUser={followedByDisplayUser}
-          followingDisplayUser={followingDisplayUser}
+          connectionsList={connectionsList(relations)}
         />
       )}
     </div>

--- a/src/components/ConnectionsListProfiles.tsx
+++ b/src/components/ConnectionsListProfiles.tsx
@@ -18,16 +18,12 @@ enum ListStatus {
 
 interface ConnectionsListProfilesProps {
   userId: string;
-  listStatus: ListStatus;
-  followedByDisplayUser: Record<string, RelationshipState>;
-  followingDisplayUser: Record<string, RelationshipState>;
+  connectionsList: User[];
 }
 
 const ConnectionsListProfiles = ({
   userId,
-  listStatus,
-  followedByDisplayUser,
-  followingDisplayUser,
+  connectionsList,
 }: ConnectionsListProfilesProps): JSX.Element => {
   const users: Record<string, User> = useAppSelector(
     (state) => state.profiles?.profiles || {}
@@ -36,29 +32,6 @@ const ConnectionsListProfiles = ({
   const followedByCurrentUser = useAppSelector(
     (state) => (userId && state.graphs.following[userId]) || {}
   );
-
-  const profileForId = (userId: string): User =>
-    users[userId] || {
-      contentHash: "",
-      url: "",
-      announcementType: AnnouncementType.Profile,
-      fromId: userId,
-      handle: "unknown",
-    };
-
-  const relations =
-    listStatus === ListStatus.FOLLOWERS
-      ? followingDisplayUser
-      : listStatus === ListStatus.FOLLOWING
-      ? followedByDisplayUser
-      : {};
-
-  const connectionsList = Object.keys(relations)
-    .map(profileForId)
-    .filter(
-      (profile) =>
-        relations[profile.fromId]?.status !== RelationshipStatus.UNFOLLOWING
-    );
 
   return (
     <>

--- a/src/components/ConnectionsListProfiles.tsx
+++ b/src/components/ConnectionsListProfiles.tsx
@@ -2,19 +2,8 @@ import React from "react";
 import UserAvatar from "./UserAvatar";
 import { User } from "../utilities/types";
 import { useAppSelector } from "../redux/hooks";
-import { AnnouncementType } from "@dsnp/sdk/core/announcements";
-import {
-  RelationshipState,
-  RelationshipStatus,
-} from "../redux/slices/graphSlice";
 import GraphChangeButton from "./GraphChangeButton";
 import { UserName } from "./UserName";
-
-enum ListStatus {
-  CLOSED,
-  FOLLOWERS,
-  FOLLOWING,
-}
 
 interface ConnectionsListProfilesProps {
   userId: string;

--- a/src/components/ConnectionsListProfiles.tsx
+++ b/src/components/ConnectionsListProfiles.tsx
@@ -68,11 +68,13 @@ const ConnectionsListProfiles = ({
           <div className="ConnectionsListProfiles__name">
             <UserName user={user} />
           </div>
-          <GraphChangeButton
-            userId={userId}
-            user={user}
-            following={followedByCurrentUser}
-          />
+          {userId !== user.fromId && (
+            <GraphChangeButton
+              userId={userId}
+              user={user}
+              following={followedByCurrentUser}
+            />
+          )}
         </div>
       ))}
     </>

--- a/src/components/test/ConnectionsList.test.tsx
+++ b/src/components/test/ConnectionsList.test.tsx
@@ -7,6 +7,7 @@ import {
 } from "../../test/testhelpers";
 import { getPreFabSocialGraph } from "../../test/testGraphs";
 import { getPrefabProfile } from "../../test/testProfiles";
+import { waitFor } from "@testing-library/react";
 
 const profile = getPrefabProfile(0);
 const graphs = getPreFabSocialGraph();
@@ -27,10 +28,17 @@ describe("ConnectionsList", () => {
     it("displays correct list title on followers click", async () => {
       const component = mount(componentWithStore(ConnectionsList, store));
       await forcePromiseResolve();
-      component.find(".ConnectionsList__button").first().simulate("click");
-      expect(component.find("ConnectionsListProfiles").prop("listStatus")).toBe(
-        1
-      );
+      const followersButton = component
+        .find(".ConnectionsList__button")
+        .first();
+      followersButton.simulate("click");
+      await waitFor(() => {
+        console.log(followersButton.debug());
+
+        expect(
+          followersButton.hasClass("ConnectionsList__button--active")
+        ).toBeTruthy();
+      });
     });
 
     it("displays correct list title on following click", async () => {

--- a/src/components/test/ConnectionsList.test.tsx
+++ b/src/components/test/ConnectionsList.test.tsx
@@ -6,14 +6,23 @@ import {
   createMockStore,
 } from "../../test/testhelpers";
 import { getPreFabSocialGraph } from "../../test/testGraphs";
-import { getPrefabProfile } from "../../test/testProfiles";
+import { preFabProfiles } from "../../test/testProfiles";
 import { waitFor } from "@testing-library/react";
+import { User } from "../../utilities/types";
 
-const profile = getPrefabProfile(0);
+const mockUserList: User[] = [
+  preFabProfiles[0],
+  preFabProfiles[1],
+  preFabProfiles[2],
+  preFabProfiles[3],
+  preFabProfiles[4],
+];
+
+const profiles = mockUserList.reduce((m, p) => ({ ...m, [p.fromId]: p }), {});
 const graphs = getPreFabSocialGraph();
 const store = createMockStore({
-  user: { id: profile.fromId },
-  profiles: [],
+  user: { id: mockUserList[0].fromId, displayId: mockUserList[2].fromId },
+  profiles: profiles,
   graphs: graphs,
 });
 
@@ -28,15 +37,13 @@ describe("ConnectionsList", () => {
     it("displays correct list title on followers click", async () => {
       const component = mount(componentWithStore(ConnectionsList, store));
       await forcePromiseResolve();
-      const followersButton = component
-        .find(".ConnectionsList__button")
-        .first();
-      followersButton.simulate("click");
+      component.find(".ConnectionsList__button").first().simulate("click");
       await waitFor(() => {
-        console.log(followersButton.debug());
-
         expect(
-          followersButton.hasClass("ConnectionsList__button--active")
+          component
+            .find(".ConnectionsList__button")
+            .first()
+            .hasClass("ConnectionsList__button--active")
         ).toBeTruthy();
       });
     });
@@ -45,19 +52,28 @@ describe("ConnectionsList", () => {
       const component = mount(componentWithStore(ConnectionsList, store));
       await forcePromiseResolve();
       component.find(".ConnectionsList__button").last().simulate("click");
-      expect(component.find("ConnectionsListProfiles").prop("listStatus")).toBe(
-        2
-      );
+      await waitFor(() => {
+        expect(
+          component
+            .find(".ConnectionsList__button")
+            .last()
+            .hasClass("ConnectionsList__button--active")
+        ).toBeTruthy();
+      });
     });
 
     it("hides list on double click", async () => {
       const component = mount(componentWithStore(ConnectionsList, store));
       await forcePromiseResolve();
       component.find(".ConnectionsList__button").last().simulate("click");
-      component.find(".ConnectionsList__button").last().simulate("click");
-      expect(component.find("ConnectionsListProfiles").prop("listStatus")).toBe(
-        0
-      );
+      await waitFor(() => {
+        expect(
+          component
+            .find(".ConnectionsList__button")
+            .first()
+            .hasClass("ConnectionsList__button--active")
+        ).not.toBeTruthy();
+      });
     });
 
     it("switches back and forth between lists", async () => {
@@ -65,9 +81,65 @@ describe("ConnectionsList", () => {
       await forcePromiseResolve();
       component.find(".ConnectionsList__button").first().simulate("click");
       component.find(".ConnectionsList__button").last().simulate("click");
-      expect(component.find("ConnectionsListProfiles").prop("listStatus")).toBe(
-        2
-      );
+      await waitFor(() => {
+        expect(
+          component
+            .find(".ConnectionsList__button")
+            .last()
+            .hasClass("ConnectionsList__button--active")
+        ).toBeTruthy();
+      });
+    });
+  });
+
+  describe("profiles filtered", () => {
+    it("filters followers", async () => {
+      const component = mount(componentWithStore(ConnectionsList, store));
+      component.find(".ConnectionsList__button").first().simulate("click");
+      await waitFor(() => {
+        expect(
+          (component
+            .find("ConnectionsListProfiles")
+            .prop("connectionsList") as User[]).length
+        ).toEqual(1);
+      });
+    });
+
+    it("filters following", async () => {
+      const component = mount(componentWithStore(ConnectionsList, store));
+      component.find(".ConnectionsList__button").last().simulate("click");
+      await waitFor(() => {
+        expect(
+          (component
+            .find("ConnectionsListProfiles")
+            .prop("connectionsList") as User[]).length
+        ).toEqual(6);
+      });
+    });
+
+    it("profiles empty on closed", async () => {
+      const component = mount(componentWithStore(ConnectionsList, store));
+      await waitFor(() => {
+        expect(
+          (component
+            .find("ConnectionsListProfiles")
+            .prop("connectionsList") as User[]).length
+        ).toEqual(0);
+      });
+    });
+
+    it("profiles empty on double click closed", async () => {
+      const component = mount(componentWithStore(ConnectionsList, store));
+      component.find(".ConnectionsList__button").last().simulate("click");
+      component.find(".ConnectionsList__button").last().simulate("click");
+
+      await waitFor(() => {
+        expect(
+          (component
+            .find("ConnectionsListProfiles")
+            .prop("connectionsList") as User[]).length
+        ).toEqual(0);
+      });
     });
   });
 });

--- a/src/components/test/ConnectionsListProfiles.test.tsx
+++ b/src/components/test/ConnectionsListProfiles.test.tsx
@@ -6,14 +6,9 @@ import {
   RelationshipState,
   RelationshipStatus,
 } from "../../redux/slices/graphSlice";
+import { User } from "../../utilities/types";
 
-enum ListStatus {
-  CLOSED,
-  FOLLOWERS,
-  FOLLOWING,
-}
-
-const mockUserList = [
+const mockUserList: User[] = [
   preFabProfiles[0],
   preFabProfiles[1],
   preFabProfiles[2],
@@ -23,12 +18,17 @@ const mockUserList = [
 
 const profiles = mockUserList.reduce((m, p) => ({ ...m, [p.fromId]: p }), {});
 
+const followingUserList: User[] = mockUserList.slice(0, 3);
+
+const followersUserList: User[] = mockUserList.slice(2);
+
 const followState = {
   status: RelationshipStatus.FOLLOWING,
   blockNumber: 0,
   blockIndex: 0,
   batchIndex: 0,
 };
+
 const following: Record<
   string,
   Record<string, RelationshipState>
@@ -52,39 +52,19 @@ describe("ConnectionsListProfiles", () => {
     expect(() => {
       shallow(
         componentWithStore(ConnectionsListProfiles, createMockStore(store), {
-          listStatus: ListStatus.FOLLOWING,
-          followedByDisplayUser: following,
-          followingDisplayUser: followers,
           userId: userId,
+          connectionsList: mockUserList,
         })
       );
     }).not.toThrow();
-  });
-
-  describe("when in closed mode", () => {
-    it("hides all connections", () => {
-      const component = mount(
-        componentWithStore(ConnectionsListProfiles, createMockStore(store), {
-          listStatus: ListStatus.CLOSED,
-          followedByDisplayUser: following,
-          followingDisplayUser: followers,
-          userId: userId,
-        })
-      );
-      expect(component.find(".ConnectionsListProfiles__profile").length).toBe(
-        0
-      );
-    });
   });
 
   describe("when in following mode", () => {
     it("shows all connections user is following", () => {
       const component = mount(
         componentWithStore(ConnectionsListProfiles, createMockStore(store), {
-          listStatus: ListStatus.FOLLOWING,
-          followedByDisplayUser: following,
-          followingDisplayUser: followers,
           userId: userId,
+          connectionsList: followingUserList,
         })
       );
       expect(component.find(".ConnectionsListProfiles__profile").length).toBe(
@@ -104,10 +84,8 @@ describe("ConnectionsListProfiles", () => {
     it("all connections can be unfollowed", () => {
       const component = mount(
         componentWithStore(ConnectionsListProfiles, createMockStore(store), {
-          listStatus: ListStatus.FOLLOWING,
-          followedByDisplayUser: following,
-          followingDisplayUser: followers,
           userId: userId,
+          connectionsList: followingUserList,
         })
       );
       expect(component.find(".GraphChangeButton").at(0).text()).toContain(
@@ -126,9 +104,8 @@ describe("ConnectionsListProfiles", () => {
     it("shows all followers", () => {
       const component = mount(
         componentWithStore(ConnectionsListProfiles, createMockStore(store), {
-          listStatus: ListStatus.FOLLOWERS,
-          followedByDisplayUser: following,
-          followingDisplayUser: followers,
+          userId: userId,
+          connectionsList: followersUserList,
         })
       );
       expect(component.find(".ConnectionsListProfiles__profile").length).toBe(
@@ -148,10 +125,8 @@ describe("ConnectionsListProfiles", () => {
     it("all followers can be followed or unfollowed depending on status", () => {
       const component = mount(
         componentWithStore(ConnectionsListProfiles, createMockStore(store), {
-          listStatus: ListStatus.FOLLOWERS,
-          followedByDisplayUser: following,
-          followingDisplayUser: followers,
           userId: userId,
+          connectionsList: followersUserList,
         })
       );
       expect(

--- a/src/components/test/EditRegistration.test.tsx
+++ b/src/components/test/EditRegistration.test.tsx
@@ -152,7 +152,6 @@ describe("EditRegistration", () => {
         .find(".EditRegistrationAccordion__panelTitle")
         .last()
         .simulate("click");
-      console.log(component.debug());
       expect(
         component.find(".SelectHandle__footerBtn").last().prop("disabled")
       ).toBe(true);
@@ -197,7 +196,6 @@ describe("EditRegistration", () => {
       });
 
       it("displays create handle form", async () => {
-        console.log(component.debug());
         await waitFor(() => {
           expect(component.find("form").props().id).toEqual("createHandle");
         });


### PR DESCRIPTION
Purpose
---------------
As a user, I want to see the correct follower/following list based on my graph.

Solution
---------------
Set and filter the connectionsList in the parent component, `ConnectionsList` instead of in the child component.  We were not initially filtering out the users that did not have the correct status, therefor giving us an inaccurate count in cases such as if you are following then unfollow a user.

Change summary
---------------
* made connectionsList a function that is passed the list that we want to filter.
* calls connectionsList(followers/following).length to get followers/following count
* calls connectionsList(currentRelation) to get open connections list and sends that as a prop to `ConnectionsListProfiles`;

Steps to Verify
----------------
1. Follow a user
2. unfollow that user
3. see that the followers/following count is correct
4. follow that user again
5. see that followers/following count is correct