### PR TITLE
Feature/display video thumbnail/179326255

### DIFF
--- a/src/components/EditRegistrationAccordion.tsx
+++ b/src/components/EditRegistrationAccordion.tsx
@@ -28,10 +28,8 @@ const EditRegistrationAccordion = ({
   const getDefaultActiveKey = () => {
     if (userId) return undefined;
     if (registrations.length === 0) {
-      console.log("registrations 1", registrations);
       return "0";
     }
-    console.log("registrations 2", registrations);
     return "1";
   };
   return (

--- a/src/components/NewPostImageUpload.tsx
+++ b/src/components/NewPostImageUpload.tsx
@@ -43,6 +43,16 @@ const NewPostImageUpload = ({
       <div className="NewPostImageUpload__cover">
         {uriList &&
           uriList.map((image, index) => {
+            const isYoutubeVideo = image.match(
+              /^https?\:\/\/(?:www\.youtube(?:\-nocookie)?\.com\/|m\.youtube\.com\/|youtube\.com\/)?(?:ytscreeningroom\?vi?=|youtu\.be\/|vi?\/|user\/.+\/u\/\w{1,2}\/|embed\/|watch\?(?:.*\&)?vi?=|\&vi?=|\?(?:.*\&)?vi?=)([^#\&\?\n\/<>"']*)/i
+            );
+            if (isYoutubeVideo) {
+              image =
+                "https://img.youtube.com/vi/" +
+                isYoutubeVideo[1] +
+                "/mqdefault.jpg";
+            }
+
             return (
               <div className="NewPostImageUpload__imageBlock" key={index}>
                 <img alt="" className="NewPostImageUpload__image" src={image} />

--- a/src/components/NewPostImageUpload.tsx
+++ b/src/components/NewPostImageUpload.tsx
@@ -1,5 +1,9 @@
 import { Alert, Input } from "antd";
-import { CloseCircleTwoTone, CameraOutlined } from "@ant-design/icons";
+import {
+  CloseCircleTwoTone,
+  CameraOutlined,
+  PictureOutlined,
+} from "@ant-design/icons";
 import React from "react";
 import { HexString } from "../utilities/types";
 import { Button } from "antd";
@@ -38,24 +42,43 @@ const NewPostImageUpload = ({
     setUriList(deletedImageArray);
     onNewPostImageUpload(deletedImageArray);
   };
+
+  const getThumbnail = (uri: string): string | undefined => {
+    const isYoutubeVideo = uri.match(
+      /^https?\/\/(?:www\.youtube(?:nocookie)?\.com\/|m\.youtube\.com\/|youtube\.com\/)?(?:ytscreeningroom\?vi?=|youtu\.be\/|vi?\/|user\/.+\/u\/\w{1,2}\/|embed\/|watch\?(?:.*)?vi?=|vi?=|\?(?:.*)?vi?=)([^#\n/<>"']*)/i
+    );
+    if (isYoutubeVideo)
+      return (
+        "https://img.youtube.com/vi/" + isYoutubeVideo[1] + "/mqdefault.jpg"
+      );
+    const isVimeo = uri.match(/\/\/(?:www\.)?vimeo.com\/([0-9a-z\-_]+)/i);
+    if (isVimeo) return "https://vumbnail.com/" + isVimeo[1] + ".jpg";
+
+    const isImage = uri.match(/\.(jpeg|jpg|gif|png|svg)$/);
+    if (isImage) return uri;
+
+    return;
+  };
+
   return (
     <>
       <div className="NewPostImageUpload__cover">
         {uriList &&
-          uriList.map((image, index) => {
-            const isYoutubeVideo = image.match(
-              /^https?\:\/\/(?:www\.youtube(?:\-nocookie)?\.com\/|m\.youtube\.com\/|youtube\.com\/)?(?:ytscreeningroom\?vi?=|youtu\.be\/|vi?\/|user\/.+\/u\/\w{1,2}\/|embed\/|watch\?(?:.*\&)?vi?=|\&vi?=|\?(?:.*\&)?vi?=)([^#\&\?\n\/<>"']*)/i
-            );
-            if (isYoutubeVideo) {
-              image =
-                "https://img.youtube.com/vi/" +
-                isYoutubeVideo[1] +
-                "/mqdefault.jpg";
-            }
-
+          uriList.map((uri, index) => {
+            const thumbnail = getThumbnail(uri);
             return (
               <div className="NewPostImageUpload__imageBlock" key={index}>
-                <img alt="" className="NewPostImageUpload__image" src={image} />
+                {thumbnail ? (
+                  <img
+                    alt=""
+                    className="NewPostImageUpload__image"
+                    src={thumbnail}
+                  />
+                ) : (
+                  <div className="NewPostImageUpload__imageAlt">
+                    <PictureOutlined />
+                  </div>
+                )}
                 <CloseCircleTwoTone
                   className="NewPostImageUpload__imageDelete"
                   onClick={() => deleteImage(index)}

--- a/src/components/scss/NewPostImageUpload.scss
+++ b/src/components/scss/NewPostImageUpload.scss
@@ -31,6 +31,18 @@
   margin: 10px;
 }
 
+.NewPostImageUpload__imageAlt {
+  width: 100px;
+  height: 100px;
+  margin: 10px;
+  background-color: $light-gray;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 30px;
+  color: $gray;
+}
+
 .NewPostImageUpload__placeholder {
   width: 100px;
   height: 100px;


### PR DESCRIPTION
Purpose
---------------
As a user, I would like to be able to see a thumbnail for the video that I am attempting to include in a new post rather than the default icon, which looks like there is an error with the link.

Solution
---------------
- If there is a thumbnail in the metadata, show that thumbnail.
- else, display a video icon so it at least looks valid

Change summary
---------------
* remove console.logs that got in from former PR
* created `getThumbnail` function that checks if youtube, vimeo, or image, and returns the thumbnail URL or null;
* if thumbnail is null, display alt thumbnail image
* add scss for alt thumbnail

Steps to Verify
----------------
- works for Youtube, Vimeo, mp4, and any other accepted video formats
- if you upload a link that is valid but does not provide a thumbnail, such as a Soundcloud link, see the catch-all UI.

Additional details / screenshot
----------------
Thumbnails in order of links:
- soundcloud
- youtube
- image
- vimeo

![Screen Shot 2021-10-07 at 12 07 26 PM](https://user-images.githubusercontent.com/43625033/136447193-340b2b32-d767-461f-933d-1f8e2e4c6b69.png)

