### PR TITLE
added try catch when opening a parquet file

### DIFF
--- a/src/services/dsnp.ts
+++ b/src/services/dsnp.ts
@@ -185,12 +185,16 @@ export const readBatchFile = async (
   rowHandler: AnnouncementRowHandler
 ): Promise<void> => {
   let batchIndex = 0;
-  const reader = await core.batch.openURL(
-    (batchAnnouncement.fileUrl.toString() as any) as URL
-  );
-  await core.batch.readFile(reader, (announcementRow: SignedAnnouncement) =>
-    rowHandler(announcementRow, batchIndex++)
-  );
+  try {
+    const reader = await core.batch.openURL(
+      batchAnnouncement.fileUrl.toString()
+    );
+    await core.batch.readFile(reader, (announcementRow: SignedAnnouncement) =>
+      rowHandler(announcementRow, batchIndex++)
+    );
+  } catch (e) {
+    console.error("Failed to read batch: ", e);
+  }
 };
 
 /**


### PR DESCRIPTION
Purpose
---------------
bug
[https://www.pivotaltracker.com/story/show/179581421](https://www.pivotaltracker.com/story/show/179581421)

When I load https://dev-expclient.liberti.social/ in Chrome, I see media.

When I load https://dev-expclient.liberti.social/ in Firefox (93.0b4) media does not load (looks like a float clear type issue).

Solution
---------------
- update firefox
- add try catch so it doesn't blow up if it fails to ready the url

Change summary
---------------
* add try catch to read url


Steps to Verify
----------------
1. run ec in firefox and check that your browser is updated and it works