### PR TITLE
fix docker deploy to update latest version when needed

### DIFF
--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -8,7 +8,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
-
+        with:
+          fetch-depth: '0'
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v1
 
@@ -20,19 +21,53 @@ jobs:
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
-      - name: Get the tag name
+
+      - name: Get the new tag version
         run: |
           echo ${GITHUB_REF##*/}
-          echo "TAG=${GITHUB_REF##*/}" >> $GITHUB_ENV
+          echo "NEW_TAG_VERSION=${GITHUB_REF##*/}" >> $GITHUB_ENV
+
+      - name: Find commit for latest tag
+        run:  |
+          COMMIT=$(git rev-list -n 1 docker/latest)
+          echo "COMMIT_FOR_LATEST_TAG=${COMMIT}" >> $GITHUB_ENV
+
+      - name: Find tag version associated with latest tag
+        run: |
+          LATEST_TAG_VERSION=$(git tag --list "docker/v*" --points-at ${{env.COMMIT_FOR_LATEST_TAG}})
+          echo "LATEST_TAG_VERSION=${LATEST_TAG_VERSION}" >> $GITHUB_ENV
+
+      - name: Check Tag Versions
+        uses: actions/github-script@v5
+        id: set-result
+        env:
+          LATEST_TAG_VERSION: ${{env.LATEST_TAG_VERSION}}
+          NEW_TAG_VERSION: ${{env.NEW_TAG_VERSION}}
+        with:
+          script: |
+            const returnTagComparison = require('./.github/workflows/tagComparison.js')
+            return returnTagComparison()
+
+          result-encoding: string
 
       - name: Build and push dsnp/example-client
+        if: steps.set-result.outputs.result == 'false'
         id: docker_build_example-client
         uses: docker/build-push-action@v2
         with:
           push: true
           file: Dockerfile
           tags: |
-            dsnp/example-client:${{ env.TAG }}
+            dsnp/example-client:${{ env.NEW_TAG_VERSION }}
+
+      - name: Build and push dsnp/example-client:latest
+        if: steps.set-result.outputs.result == 'true'
+        id: docker_build_example-client-latest
+        uses: docker/build-push-action@v2
+        with:
+          push: true
+          file: Dockerfile
+          tags: dsnp/example-client:${{ env.NEW_TAG_VERSION }}, dsnp/example-client:latest
 
       - name: Image digests
         run: |

--- a/.github/workflows/tagComparison.js
+++ b/.github/workflows/tagComparison.js
@@ -1,0 +1,42 @@
+
+const tagVersionSplit = (tagVersionArray) => {
+    const tagVersionMissingNumArray = tagVersionArray.length == 3 ? [] : Array(3 - tagVersionArray.length).fill("0")
+    return tagVersionArray.concat(tagVersionMissingNumArray)
+}
+
+const newTagGreaterThanLatest = (newTagArray, latestTagArray) => {
+    for (let i = 0; i < 3; i++) {
+        if (newTagArray[i] > latestTagArray[i]) {
+            return "true"
+        } else if (latestTagArray[i] > newTagArray[i]) {
+            return "false"
+        }
+    }
+}
+
+const compareTagVersions = (latestTag, newTag) => {
+
+    if (!latestTag) {
+        return "true"
+    }
+
+    const latestTagVersion = latestTag.split('docker/v')
+    const newTagVersion = newTag.split('v')
+
+    if (latestTagVersion == newTagVersion) {
+        return "false"
+    }
+
+    const latestTagVersionArray = latestTagVersion[1].split('.')
+    const newTagVersionArray = newTagVersion[1].split('.')
+
+    const updatedLatestTagVersionArray = tagVersionSplit(latestTagVersionArray)
+    const updatedNewTagVersionArray = tagVersionSplit(newTagVersionArray)
+
+    return newTagGreaterThanLatest(updatedNewTagVersionArray, updatedLatestTagVersionArray)
+}
+
+module.exports = () => {
+    const { LATEST_TAG_VERSION , NEW_TAG_VERSION } = process.env
+    return compareTagVersions(LATEST_TAG_VERSION, NEW_TAG_VERSION)
+}


### PR DESCRIPTION
Problem
---------------
[Finishes 179608496](https://www.pivotaltracker.com/n/projects/2436354/stories/179608496)

Currently our docker latest tag is not automatically updated when a new tag version of example client is pushed.

Solution
---------------
Changed docker workflow to update latest version when a new version of example client is pushed.


Change summary
---------------
* Updated the docker-release yaml file
* Checks if newest version is greater than the last latest version before updating

