### PR TITLE
centered text on button

### DIFF
--- a/src/components/scss/CreateRegistration.scss
+++ b/src/components/scss/CreateRegistration.scss
@@ -16,7 +16,6 @@
 .CreateRegistration__footerBtn {
   text-align: center;
   overflow: auto;
-  padding-top: 10px;
 }
 
 .CreateRegistration__errorIcon {


### PR DESCRIPTION
Purpose
---------------
bug

Related GitHub Issues
---------------
[https://github.com/LibertyDSNP/example-client/issues/139](https://github.com/LibertyDSNP/example-client/issues/139)

Solution
---------------
remove excess padding

Change summary
---------------
* remove excess padding on button
* ran a deployment of the github pages to check the build version looked good

Steps to Verify
----------------
1. see that text is centered


Additional details / screenshot
----------------
<img width="1435" alt="Screen Shot 2021-11-12 at 12 25 03 PM" src="https://user-images.githubusercontent.com/43625033/141530814-0656fbd4-59ea-46a4-90cb-0b69feac9916.png">

