### PR TITLE
edit registration modal only closes on log in

### DIFF
--- a/src/components/ConnectWallet.tsx
+++ b/src/components/ConnectWallet.tsx
@@ -44,6 +44,12 @@ const ConnectWallet = (): JSX.Element => {
     setRegistrationPopoverVisible(false);
   };
 
+  const toggleRegistrationPopoverVisible = () => {
+    const currentState = registrationPopoverVisible;
+    startLoading(!currentState);
+    setRegistrationPopoverVisible(!currentState);
+  };
+
   useEffect(() => {
     if (currentWalletType && currentWalletType !== wallet.WalletType.NONE) {
       // Ensure wallet address is set for all components this component owns.
@@ -153,7 +159,7 @@ const ConnectWallet = (): JSX.Element => {
         >
           <div
             className="ConnectWallet__userBlock"
-            onClick={() => setRegistrationPopoverVisible(true)}
+            onClick={() => toggleRegistrationPopoverVisible()}
           >
             <UserAvatar user={user} avatarSize="small" />
             <div className="ConnectWallet__userTitle">

--- a/src/components/ConnectWallet.tsx
+++ b/src/components/ConnectWallet.tsx
@@ -113,12 +113,6 @@ const ConnectWallet = (): JSX.Element => {
     setRegistrations([...registrations, registration]);
   };
 
-  const handleVisibleChange = (visible: boolean) => {
-    setRegistrationPopoverVisible(visible);
-    // Signal if user closes the modal.
-    if (!userId && !visible) logout();
-  };
-
   const closeModals = () => {
     startLoading(false);
     setRegistrationPopoverVisible(false);
@@ -146,7 +140,6 @@ const ConnectWallet = (): JSX.Element => {
           placement="bottomRight"
           visible={registrationPopoverVisible}
           trigger="click"
-          onVisibleChange={handleVisibleChange}
           content={
             <EditRegistration
               logout={logout}
@@ -154,10 +147,14 @@ const ConnectWallet = (): JSX.Element => {
               onIdResolved={setUserID}
               registrations={registrations}
               registrationCreated={registrationCreated}
+              setRegistrationPopoverVisible={setRegistrationPopoverVisible}
             />
           }
         >
-          <div className="ConnectWallet__userBlock">
+          <div
+            className="ConnectWallet__userBlock"
+            onClick={() => setRegistrationPopoverVisible(true)}
+          >
             <UserAvatar user={user} avatarSize="small" />
             <div className="ConnectWallet__userTitle">
               {user?.handle ? "@" + user.handle : profile?.name || user?.fromId}

--- a/src/components/EditRegistration.tsx
+++ b/src/components/EditRegistration.tsx
@@ -13,6 +13,7 @@ interface EditRegistrationProps {
   onIdResolved: (uri: DSNPUserURI) => void;
   registrations: Registration[];
   registrationCreated: (registration: Registration) => void;
+  setRegistrationPopoverVisible: (visible: boolean) => void;
 }
 
 const EditRegistration = ({
@@ -21,6 +22,7 @@ const EditRegistration = ({
   onIdResolved,
   registrations,
   registrationCreated,
+  setRegistrationPopoverVisible,
 }: EditRegistrationProps): JSX.Element => {
   const userId = useAppSelector((state) => state.user.id);
   const [registrationPreview, setRegistrationPreview] = useState<
@@ -43,7 +45,16 @@ const EditRegistration = ({
           </p>
         </>
       ) : (
-        <p className="EditRegistration__title">Edit</p>
+        <div className="EditRegistration__header">
+          <p className="EditRegistration__title">Edit</p>
+          <Button
+            type="link"
+            className="EditRegistration__closeModalButton"
+            onClick={() => setRegistrationPopoverVisible(false)}
+          >
+            Cancel
+          </Button>
+        </div>
       )}
       <RegistrationPreview registrationPreview={registrationPreview} />
       <EditRegistrationAccordion

--- a/src/components/EditRegistration.tsx
+++ b/src/components/EditRegistration.tsx
@@ -33,13 +33,6 @@ const EditRegistration = ({
     <div className="EditRegistration">
       {!userId ? (
         <>
-          <Button
-            type="link"
-            className="EditRegistration__cancel"
-            onClick={logout}
-          >
-            Cancel
-          </Button>
           <p className="EditRegistration__title">
             Successfully connected to your wallet.
           </p>
@@ -47,13 +40,6 @@ const EditRegistration = ({
       ) : (
         <div className="EditRegistration__header">
           <p className="EditRegistration__title">Edit</p>
-          <Button
-            type="link"
-            className="EditRegistration__closeModalButton"
-            onClick={() => setRegistrationPopoverVisible(false)}
-          >
-            Cancel
-          </Button>
         </div>
       )}
       <RegistrationPreview registrationPreview={registrationPreview} />
@@ -64,13 +50,32 @@ const EditRegistration = ({
         registrations={registrations}
         registrationCreated={registrationCreated}
       />
-      <Button
-        className="EditRegistration__logoutButton"
-        aria-label="Logout"
-        onClick={logout}
-      >
-        Sign Out
-      </Button>
+      <div className="EditRegistration__buttonRow">
+        <Button
+          className="EditRegistration__logoutButton"
+          aria-label="Logout"
+          onClick={logout}
+        >
+          Sign Out
+        </Button>
+        {!userId ? (
+          <Button
+            type="link"
+            className="EditRegistration__cancel"
+            onClick={logout}
+          >
+            Cancel
+          </Button>
+        ) : (
+          <Button
+            type="link"
+            className="EditRegistration__closeModalButton"
+            onClick={() => setRegistrationPopoverVisible(false)}
+          >
+            Cancel
+          </Button>
+        )}
+      </div>
     </div>
   );
 };

--- a/src/components/scss/EditRegistration.scss
+++ b/src/components/scss/EditRegistration.scss
@@ -11,13 +11,18 @@
   line-height: 1.2;
 }
 
+.EditRegistration__buttonRow {
+  margin-top: 16px;
+  display: flex;
+  justify-content: space-between;
+}
+
 .EditRegistration__cancel {
   color: $shadow-green !important;
-  align-self: end;
+  justify-content: flex-end;
 }
 
 .EditRegistration__logoutButton {
-  margin-top: 16px;
   width: fit-content;
 }
 

--- a/src/components/scss/EditRegistration.scss
+++ b/src/components/scss/EditRegistration.scss
@@ -20,3 +20,12 @@
   margin-top: 16px;
   width: fit-content;
 }
+
+.EditRegistration__closeModalButton {
+  color: $shadow-green !important;
+}
+
+.EditRegistration__header {
+  display: flex;
+  justify-content: space-between;
+}


### PR DESCRIPTION
Purpose
---------------
Currently, clicking out of the editRegistration popover would close the modal. The purpose of this is to make it so that users have to click on the cancel button in order to close the menu and not anything else.

Related GitHub Issues
---------------
[Github Issue #141](https://github.com/LibertyDSNP/example-client/issues/141)

Solution
---------------
- Made the modal to be restricted to only closing on a cancel click

Change summary
---------------
- Removed a function that no longer was used with the new functionality
- Added an additional cancel button after a user logged in since there is no cancel button on the registration modal after logged in.


Steps to Verify
----------------
1. Switch MetaMask to an account that does NOT have any registrations.
2. Press "Connect Wallet"
3. Click anywhere outside the menu and notice that the menu does not close.
4. Click the cancel button and it closes the menu
5. Log in with the create handle button by connecting again
6. Click on the avatar circle on the top right to reopen the menu
7. Check again that the menu does not close at clicking outside it
8. The cancel button that is newly implemented in this pr should be there so that users could leave the screen

